### PR TITLE
MatTable bug where LoadData would throw exception when using Filter

### DIFF
--- a/src/MatBlazor/MatTable.razor
+++ b/src/MatBlazor/MatTable.razor
@@ -199,7 +199,7 @@
             Console.WriteLine("Error LoadData: " + ex.Message);
             ErrorMessage = ex.Message;
         }
-        this.StateHasChanged();
+        base.Invoke(StateHasChanged);
     }
 
     async Task SearchData()

--- a/src/MatBlazor/MatTable.razor
+++ b/src/MatBlazor/MatTable.razor
@@ -199,7 +199,7 @@
             Console.WriteLine("Error LoadData: " + ex.Message);
             ErrorMessage = ex.Message;
         }
-        base.Invoke(StateHasChanged);
+        await base.Invoke(StateHasChanged);
     }
 
     async Task SearchData()


### PR DESCRIPTION
Fixed a bug with MatTable where LoadData would throw an exception when using the Filter function.
This is present in the master and can be tested on the [demo page](https://www.matblazor.com/Table)