### PR TITLE
Typo. Mode is hardcoded

### DIFF
--- a/src/MatBlazor.Web/src/matLayoutGrid/matLayoutGrid.scss
+++ b/src/MatBlazor.Web/src/matLayoutGrid/matLayoutGrid.scss
@@ -21,7 +21,7 @@
 
 @for $col from 1 through 12 {
   @each $mode in map-keys($mdc-layout-grid-columns) {
-    .mat-layout-grid-cell-span-#{$col}-desktop {
+    .mat-layout-grid-cell-span-#{$col}-#{$mode} {
       @extend .mdc-layout-grid__cell--span-#{$col}-#{$mode};
     }
   }


### PR DESCRIPTION
I guess they are a typo here. Not all [modes](https://github.com/material-components/material-components-web/blob/master/packages/mdc-layout-grid/_variables.scss) are created, only `desktop`.

Note: Notice I din't recompile js/css (main.js) after the change.