### PR TITLE
Improve Full Width Field Text Padding

### DIFF
--- a/src/MatBlazor.Web/src/matTextField/matTextField.scss
+++ b/src/MatBlazor.Web/src/matTextField/matTextField.scss
@@ -9,16 +9,17 @@
 }
 
 /* Fix Full Width padding issues */
-.mdc-text-field--fullwidth:not(.mdc-text-field--textarea) .mdc-text-field__input{
+div.mdc-text-field.mdc-text-field--fullwidth:not(.mdc-text-field--textarea)>input.mdc-text-field__input{
     padding: 20px 16px 6px;
 }
 
-.mdc-text-field--fullwidth-with-trailing-icon:not(.mdc-text-field--textarea) .mdc-text-field__input
+div.mdc-text-field--fullwidth-with-trailing-icon:not(.mdc-text-field--textarea)>input.mdc-text-field__input
 {
     padding: 20px 48px 6px 16px;
 }
 
-.mdc-text-field--fullwidth-with-leading-icon:not(.mdc-text-field--textarea) .mdc-text-field__input
+div.mdc-text-field--fullwidth-with-leading-icon:not(.mdc-text-field--textarea)>input.mdc-text-field__input
 {
     padding: 20px 16px 6px 48px;
 }
+


### PR DESCRIPTION
Fixing https://github.com/SamProf/MatBlazor/issues/129

It's not possible to override mdc padding 0 css from .scss, as a workaround (or solution?) I wrote css rule with a more specific css selector.