### PR TITLE
Outlined

### DIFF
--- a/src/MatBlazor.Web/src/matTextField/matTextField.scss
+++ b/src/MatBlazor.Web/src/matTextField/matTextField.scss
@@ -23,3 +23,7 @@ div.mdc-text-field--fullwidth-with-leading-icon:not(.mdc-text-field--textarea)>i
     padding: 20px 16px 6px 48px;
 }
 
+.mat-floating-label--float-above-outlined
+{
+    background-color:  var(--mdc-theme-surface, #fff) !important;
+}

--- a/src/MatBlazor/Components/MatTextField/BaseMatTextField.cs
+++ b/src/MatBlazor/Components/MatTextField/BaseMatTextField.cs
@@ -151,6 +151,7 @@ namespace MatBlazor
 
             LabelClassMapper
                 .Add("mdc-floating-label")
+                .If("mat-floating-label--float-above-outlined", () => Outlined && !string.IsNullOrEmpty(Value))
                 .If("mdc-floating-label--float-above", () => !string.IsNullOrEmpty(Value));
 
             InputClassMapper


### PR DESCRIPTION
There is an issue with outlined when you set values to MatTextField programatically.

Check it at [https://blazorfiddle.com/s/5klbg4rm](https://blazorfiddle.com/s/5klbg4rm):

* Go tab `FIRST`
* Set a value on MatTextField
* Go tab `SECOND`
* Press "copy-files" icon

![Selection_600](https://user-images.githubusercontent.com/3105983/62049898-7f82a500-b210-11e9-83e6-644f80b779ef.png)

I already fixed this issue on MatNumericUpDown when I wrote the component, I hope this is the right way to fix it, if there is another way, then, we should to apply on both `MatNumericUpDown` and `MatTextField`.

![Selection_599](https://user-images.githubusercontent.com/3105983/62049996-b48ef780-b210-11e9-98c6-4c86721ec03e.png)

