### PR TITLE
Fix MatAutocomplete StringValue clearing

### DIFF
--- a/src/MatBlazor/Components/MatAutocomplete/BaseMatAutocomplete.cs
+++ b/src/MatBlazor/Components/MatAutocomplete/BaseMatAutocomplete.cs
@@ -182,6 +182,7 @@ namespace MatBlazor
         public void ClearText(UIMouseEventArgs e)
         {
             Value = default;
+            StringValue = string.Empty;
             StateHasChanged();
         }
 


### PR DESCRIPTION
Explicitly clear StringValue in ClearText() method - without that, it remains populated if Value is not selected yet.