### PR TITLE
return Toast instance on IMatToaster.Add method

### DIFF
--- a/src/MatBlazor/Components/MatToastContainer/IMatToaster.cs
+++ b/src/MatBlazor/Components/MatToastContainer/IMatToaster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MatBlazor
@@ -32,7 +32,7 @@ namespace MatBlazor
         /// <param name="title">The optional toast tile</param>
         /// <param name="icon">The optional toast icon</param>
         /// <param name="configure">An action for configuring a <see cref="MatToastOptions"/> instance already containing the globally configured settings</param>
-        void Add(string message, MatToastType type, string title = null, string icon = null,
+        MatToast Add(string message, MatToastType type, string title = null, string icon = null,
             Action<MatToastOptions> configure = null);
 
         /// <summary>

--- a/src/MatBlazor/Services/Toast/MatToaster.cs
+++ b/src/MatBlazor/Services/Toast/MatToaster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,16 +16,16 @@ namespace MatBlazor
             Configuration.OnUpdate += ConfigurationUpdated;
         }
 
-        public void Add(string message, MatToastType type, string title, string icon, Action<MatToastOptions> configure)
+        public MatToast Add(string message, MatToastType type, string title, string icon, Action<MatToastOptions> configure)
         {
-            if (string.IsNullOrEmpty(message)) return;
+            if (string.IsNullOrEmpty(message)) return null;
 
             message = message.Trim();
             title = string.IsNullOrEmpty(title) ? "" : title.Trim();
 
             if (Configuration.PreventDuplicates && ToastAlreadyPresent(message, title, type))
             {
-                return;
+                return null;
             }
 
             var options = new MatToastOptions(type, Configuration);
@@ -36,6 +36,8 @@ namespace MatBlazor
             Toasts.Add(toast);
 
             OnToastsUpdated?.Invoke();
+
+            return toast;
         }
 
         public void Clear()


### PR DESCRIPTION
This return value will make the interface easier to use.
We want to add several toasts and sometimes use IMatToaster.RemoveToasts to remove the toasts before they disappear. 
Currently i have to iterate over the IMatToaster.Toasts to try to find the matching toasts and then remove it.