### PR TITLE
MatDialog: New CanBeClosed property

### DIFF
--- a/src/MatBlazor.Web/src/matDialog/matDialog.js
+++ b/src/MatBlazor.Web/src/matDialog/matDialog.js
@@ -1,6 +1,6 @@
 import './matDialog.scss';
 
-import {MDCDialog} from '@material/dialog';
+import { MDCDialog } from '@material/dialog';
 
 
 export function init(ref, component) {
@@ -9,12 +9,11 @@ export function init(ref, component) {
   ref.addEventListener('MDCDialog:closed', () => {
     component.invokeMethodAsync('MatDialogClosedHandler');
   });
-  
+
   ref.addEventListener('MDCDialog:opened', () => {
     component.invokeMethodAsync('MatDialogOpenedHandler');
   });
 }
-
 
 export function setIsOpen(ref, v) {
   if (v) {
@@ -22,5 +21,15 @@ export function setIsOpen(ref, v) {
   } else {
     ref.matBlazorRef.close();
 
+  }
+}
+
+export function setCanBeClosed(ref, v) {
+  if (v) {
+    ref.matBlazorRef.escapeKeyAction = "close";
+    ref.matBlazorRef.scrimClickAction = "close";
+  } else {
+    ref.matBlazorRef.escapeKeyAction = "";
+    ref.matBlazorRef.scrimClickAction = "";
   }
 }

--- a/src/MatBlazor/Components/MatDialog/BaseMatDialog.cs
+++ b/src/MatBlazor/Components/MatDialog/BaseMatDialog.cs
@@ -11,6 +11,9 @@ namespace MatBlazor
     {
         private bool _isOpen;
 
+        // true is the mdc default
+        private bool _canBeClosed = true;
+
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
@@ -37,11 +40,31 @@ namespace MatBlazor
         [Parameter]
         public EventCallback<bool> IsOpenChanged { get; set; }
 
+        /// <summary>
+        /// Indicates if the user is able to close the dialog via Escape or click on the Scrim.
+        /// </summary>
+        [Parameter]
+        public bool CanBeClosed
+        {
+            get => _canBeClosed;
+            set
+            {
+                if (CanBeClosed != value)
+                {
+                    _canBeClosed = value;
+                    CallAfterRender(async () =>
+                    {
+                        await JsInvokeAsync<object>("matBlazor.matDialog.setCanBeClosed", Ref, value);
+                    });
+                }
+            }
+        }
+
         private DotNetObjectReference<BaseMatDialog> dotNetObjectRef;
 
         public BaseMatDialog()
         {
-            
+
             ClassMapper.Add("mdc-dialog");
             CallAfterRender(async () =>
             {


### PR DESCRIPTION
New property that will set the _escapeKeyAction_ and _scrimClickAction_ in MDC Dialog.

If set to false the user is not able to close the dialog by pressing ESC or clicking on the scrim.
You can now use MatDialog as just a modal for ex. a modal loading screen.