### PR TITLE
#259 - Auto-Active MatNatItem

### DIFF
--- a/src/MatBlazor.Web/src/matNavMenu/matNavMenu.scss
+++ b/src/MatBlazor.Web/src/matNavMenu/matNavMenu.scss
@@ -2,6 +2,7 @@
     margin: 0;
     padding: 0;
 }
+
 .mat-accordion .mdc-nav-menu {
     .mat-expansion-panel__summary {
         padding: 0;
@@ -11,7 +12,8 @@
         padding: 0 0 0 13px;
     }
 
-    .mat-expansion-panel__content .mdc-list-item {
+    .mat-expansion-panel__content .mdc-list-item,
+    .mat-expansion-panel__content .mdc-nav-link {
         font-weight: 300;
     }
 
@@ -21,8 +23,9 @@
     }
 }
 
-.mdc-nav-item{
+.mdc-nav-item, .mdc-nav-li{
     flex-grow: 1;
+    list-style: none;
 }
 
 .mdc-sub-menu-icon {

--- a/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
+++ b/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
@@ -1,8 +1,22 @@
 ﻿@namespace MatBlazor
+@using Microsoft.AspNetCore.Components.Routing;
 @inherits BaseMatNavItem
 
-<CascadingValue Value="@this">
-    <li class="@ClassMapper.Class" @onmousedown="OnMouseDown" @onclick="OnClickHandler" style="@Style" @ref="Ref"  @attributes="Attributes" Id="@Id">
-        @ChildContent
-    </li>    
-</CascadingValue>
+    <CascadingValue Value="@this">
+
+        @if (string.IsNullOrEmpty(Href))
+        {
+            <li class="@ClassMapper.Class" @onmousedown="OnMouseDown" style="@Style" @ref="Ref" @attributes="Attributes" Id="@Id">
+                @ChildContent
+            </li>
+        }
+        else
+        {
+            <li class="mdc-nav-li" @ref="Ref" @attributes="Attributes" Id="@Id">
+                <NavLink class="@ClassMapper.Class" style="@Style" href="@Href" @onclick="OnClickHandler" Match="NavLinkMatch.All" ActiveClass="mdc-list-item--selected">
+                    @ChildContent
+                </NavLink>
+            </li>
+        }
+
+    </CascadingValue>


### PR DESCRIPTION
#259 - Adds additional functionality to the Nav Menu. Sets MatNavMenu items to be active automatically. Still has one issue where if the MatNavMenu item is a SubMenuNavItem the parent is not activated. This for 2 reasons: NavLink does not have a property that we can read if it is active. CSS does not have a Parent selector. Maybe there is some Material Javascript that I don't know of but at least this is a good start.