### PR TITLE
provide possibility to override expression used for validation

### DIFF
--- a/src/MatBlazor/Components/Base/BaseMatInputComponent.cs
+++ b/src/MatBlazor/Components/Base/BaseMatInputComponent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using System;
 using System.Collections.Generic;
@@ -82,6 +82,12 @@ namespace MatBlazor
         [Parameter]
         public Expression<Func<T>> ValueExpression { get; set; }
 
+        /// <summary>
+        /// Gets or sets an expression that identifies the bound value to validate.
+        /// </summary>
+        [Parameter]
+        public Expression<Func<T>> ValidateValueExpression { get; set; }
+
         /// <inheritdoc />
         public override Task SetParametersAsync(ParameterView parameters)
         {
@@ -97,13 +103,13 @@ namespace MatBlazor
                     EditContext = CascadedEditContext;
                     if (EditContext != null)
                     {
-                        if (ValueExpression == null)
+                        if (ValueExpression == null && ValidateValueExpression == null)
                         {
-                            throw new InvalidOperationException($"{GetType()} requires a value for the 'ValueExpression' " +
+                            throw new InvalidOperationException($"{GetType()} requires a value for the 'ValueExpression'" +
                                                                 $"parameter. Normally this is provided automatically when using 'bind-Value'.");
                         }
 
-                        FieldIdentifier = FieldIdentifier.Create(ValueExpression);
+                        FieldIdentifier = FieldIdentifier.Create(ValidateValueExpression ?? ValueExpression);
                     }
 
                     _hasSetInitialEditContext = true;


### PR DESCRIPTION
We use some textfields to bind to arrays or other not supported datatypes. We rely on DataAnnotations on our models and do not want to copy these rules to the razor files.

We created some proxy properties which convert between string and the type of the models.


![image](https://user-images.githubusercontent.com/36757014/65885539-231c3d00-e39b-11e9-9dbf-13b5d2d89945.png)

To workaround this problem we had to disable the validation of the field and manually set the validation classes. What we needed to solve our problem is a way to override the `BaseMatInputComponent<T>.FieldIdentifier` to point to the real model and not to our value-providing proxy.
Currently our code looks like this:

```
   <MatTextField InputClass="@DnsValidationClass" InputStyle="resize: none;" ValidationDisabled="true" @bind-Value="@PROXYDnsEntries" Label="DnsEntries" HelperText="(comma seperated list)" />
        <ValidationMessage For="(() => ProxySettings.DnsEntries)" />
```


```
        public string DnsValidationClass
        {
            get
            {
                if (EditContext.GetValidationMessages(EditContext.Field(nameof(TelepresenceProxy.DnsEntries))).Any())
                {
                    return "invalid";
                }
                else if (EditContext.IsModified(EditContext.Field(nameof(TelepresenceProxy.DnsEntries))))
                {
                    return "valid modified";
                }
                else
                {
                    return string.Empty;
                }
            }
        }

        public string PROXYDnsEntries
        {
            get
            {
                return ProxySettings.DnsEntries == null ? string.Empty : string.Join(", ", ProxySettings.DnsEntries);
            }
            set
            {
            {
                ProxySettings.DnsEntries = value.Split(',').Select(x => x.Trim()).ToArray();
                EditContext.NotifyFieldChanged(EditContext.Field(nameof(TelepresenceProxy
                    .DnsEntries)));
            }
        }

```




With the change from this merge request we could simplify our code like this:
```
   <MatTextField ValidateValueExpression="@(() => ProxySettings.DnsEntries)" @bind-Value="@DnsEntries"  />
        <ValidationMessage For="(() => ProxySettings.DnsEntries)" />
```

```
        public string DnsEntries
        {
            get
            {
                return ProxySettings.DnsEntries == null ? string.Empty : string.Join(", ", ProxySettings.DnsEntries);
            }
            set
            {
            {
                ProxySettings.DnsEntries = value.Split(',').Select(x => x.Trim()).ToArray();
            }
        }
```
