### PR TITLE
Workaround to enable MatAutocomplete to work inside EditForm

### DIFF
--- a/src/MatBlazor/Components/MatAutocomplete/BaseMatAutocomplete.cs
+++ b/src/MatBlazor/Components/MatAutocomplete/BaseMatAutocomplete.cs
@@ -82,6 +82,18 @@ namespace MatBlazor
         }
 
         /// <summary>
+        /// This value is only returned for use in ValueExpression (required to make MatAutocomplete work inside EditForms).
+        /// </summary>
+        protected string DummyValue
+        {
+            get
+            {
+                return " ";
+            }
+            set { }
+        }
+
+        /// <summary>
         /// The value to be used to pre-select an item from the list
         /// </summary>
         [Parameter]

--- a/src/MatBlazor/Components/MatAutocomplete/MatAutocomplete.razor
+++ b/src/MatBlazor/Components/MatAutocomplete/MatAutocomplete.razor
@@ -5,7 +5,6 @@
 
 
 <div class="@WrapperClassMapper.Class">
-    <MatTextField Icon="@Icon" OnFocus="@OpenPopup" HideClearButton="true" FullWidth="@FullWidth" OnFocusOut="@ClosePopup" Label="@Label" Value=@StringValue OnInput=@OnValueChanged OnKeyDown="@OnKeyDown" Outlined="@Outlined" Attributes="@Attributes" Id="@Id"></MatTextField>
     @if (IsShowingClearButton)
     {
         <div class="mat-autocomplete-clearbutton">
@@ -32,4 +31,5 @@
             </MatList>
         </div>
     }
+    <MatTextField Icon="@Icon" OnFocus="@OpenPopup" HideClearButton="true" FullWidth="@FullWidth" OnFocusOut="@ClosePopup" Label="@Label" Value="@StringValue" OnInput=@OnValueChanged OnKeyDown="@OnKeyDown" Outlined="@Outlined" Attributes="@Attributes" Id="@Id" ValueExpression="@(() => DummyValue)"></MatTextField>
 </div>


### PR DESCRIPTION
Enables the usage of MatAutocomplete inside EditForms by creating a dummy value for ValueExpression. We needed to get this working for our project, so we implemented the workaround introduced on #213 (and #278).

Honestly - I think the solution Sebbstar introduced on PR #272 might be prettier in the long run, if it fixes the issue as well. However, we needed to get this working internally, and I thought it'd be foolish not to at least offer the solution up for grabs, just in case it would be useful for someone.

Cheers!