### PR TITLE
Fixes issue #315 (MatAutocomplete's clear-button submits forms)

### DIFF
--- a/src/MatBlazor/Components/MatAutocomplete/MatAutocomplete.razor
+++ b/src/MatBlazor/Components/MatAutocomplete/MatAutocomplete.razor
@@ -1,4 +1,4 @@
-﻿@namespace MatBlazor
+@namespace MatBlazor
 @typeparam ItemType
 @inherits BaseMatAutocomplete<ItemType>
 @using System.Collections;
@@ -6,10 +6,11 @@
 
 <div class="@WrapperClassMapper.Class">
     <MatTextField Icon="@Icon" OnFocus="@OpenPopup" HideClearButton="true" FullWidth="@FullWidth" OnFocusOut="@ClosePopup" Label="@Label" Value=@StringValue OnInput=@OnValueChanged OnKeyDown="@OnKeyDown" Outlined="@Outlined" Attributes="@Attributes" Id="@Id"></MatTextField>
+
     @if (IsShowingClearButton)
     {
         <div class="mat-autocomplete-clearbutton">
-            <MatIconButton Icon="clear" OnMouseDown="@ClearText"></MatIconButton>
+            <MatIconButton Icon="clear" type="button" OnMouseDown="@ClearText"></MatIconButton>
         </div>
     }
     @if (Collection != null && IsOpened)

--- a/src/MatBlazor/Components/MatIconButton/MatIconButton.razor
+++ b/src/MatBlazor/Components/MatIconButton/MatIconButton.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MatBlazor
 @inherits BaseMatIconButton
 
-<button class="@ClassMapper.Class" style="@Style" @ref="Ref"  disabled=@Disabled @onclick="OnClickHandler" @onmousedown="OnMouseDown" href=@Link @attributes="Attributes" Id="@Id">
+<button class="@ClassMapper.Class" style="@Style" @ref="Ref" disabled=@Disabled @onclick="OnClickHandler" @onmousedown="OnMouseDown" href=@Link @attributes="Attributes" Id="@Id">
     @if (Icon != null)
     {
         @if (ToggleIcon != null && Toggled)


### PR DESCRIPTION
Changes the type of the MatIconButton to be "button" instead of "submit" (default) to avoid accidental submits of EditForms. This is done by changing the "type" of the MatIconButton on the MatAutocomplete component.