### PR TITLE
Allow keyboard triggered clear text event on MatAutocomplete

### DIFF
--- a/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
+++ b/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
@@ -196,7 +196,11 @@ namespace MatBlazor
             StateHasChanged();
         }
 
-        public void ClearText(MouseEventArgs e)
+        /// <summary>
+        /// Clears current value of the autocomplete text
+        /// </summary>
+        /// <param name="e"></param>
+        public void ClearText(EventArgs e)
         {
             Value = default;
             StringValue = string.Empty;

--- a/src/MatBlazor/Components/MatAutocompleteList/MatAutocompleteList.razor
+++ b/src/MatBlazor/Components/MatAutocompleteList/MatAutocompleteList.razor
@@ -9,7 +9,7 @@
     @if (IsShowingClearButton)
     {
         <div class="mat-autocomplete-list-clearbutton">
-            <MatIconButton Icon="clear" OnMouseDown="@ClearText"></MatIconButton>
+            <MatIconButton Icon="clear" OnMouseDown="@ClearText" OnClick="@ClearText"></MatIconButton>
         </div>
     }
     @if (Items != null && IsOpened)

--- a/src/MatBlazor/Components/MatAutocompleteList/MatAutocompleteList.razor
+++ b/src/MatBlazor/Components/MatAutocompleteList/MatAutocompleteList.razor
@@ -9,7 +9,7 @@
     @if (IsShowingClearButton)
     {
         <div class="mat-autocomplete-list-clearbutton">
-            <MatIconButton Icon="clear" OnMouseDown="@ClearText" OnClick="@ClearText"></MatIconButton>
+            <MatIconButton Icon="clear" OnClick="@ClearText"></MatIconButton>
         </div>
     }
     @if (Items != null && IsOpened)

--- a/src/MatBlazor/MatBlazor.xml
+++ b/src/MatBlazor/MatBlazor.xml
@@ -204,6 +204,12 @@
             <summary>
             ItemTemplate is used to render the elements in the popup if no template is given then the string value of the objects is displayed..
             </summary>
+        <member>
+        <member name="M:MatBlazor.BaseMatAutocomplete`1.ClearText(System.EventArgs)">
+            <summary>
+            Clears current value of the autocomplete text
+            </summary>
+            <param name="e"></param>
         </member>
         <member name="T:MatBlazor.BaseMatButton">
             <summary>


### PR DESCRIPTION
This allows to use keyboard based trigger to clear current text in
autocomplete. This also requires using base event type in method
definition.

Thanks!