### PR TITLE
Added ForceLoad option for MatButton and MatIconButton Fixes #330

### DIFF
--- a/src/MatBlazor.Demo/Doc/DocMatButton.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatButton.razor
@@ -70,6 +70,11 @@
 		<td>Link to a url when clicked.</td>
 	</tr>
 	<tr>
+		<td>ForceLoad</td>
+		<td>Boolean</td>
+		<td>Force browser to redirect outside component router-space.</td>
+	</tr>
+	<tr>
 		<td>Name</td>
 		<td>String</td>
 		<td></td>

--- a/src/MatBlazor.Demo/Doc/DocMatIconButton.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconButton.razor
@@ -60,6 +60,11 @@
 		<td>Navigate to this url when clicked.</td>
 	</tr>
 	<tr>
+		<td>ForceLoad</td>
+		<td>Boolean</td>
+		<td>Force browser to redirect outside component router-space.</td>
+	</tr>
+	<tr>
 		<td>OnClick</td>
 		<td>EventCallback&lt;MouseEventArgs&gt;</td>
 		<td>Event occurs when the user clicks on an element.</td>

--- a/src/MatBlazor/Components/MatButton/BaseMatButton.cs
+++ b/src/MatBlazor/Components/MatButton/BaseMatButton.cs
@@ -67,6 +67,13 @@ namespace MatBlazor
         public string Link { get; set; }
 
         /// <summary>
+        /// Force browser to redirect outside component router-space.
+        /// </summary>
+        /// 
+        [Parameter]
+        public bool ForceLoad { get; set; }
+
+        /// <summary>
         /// Button has raised style.
         /// </summary>
         [Parameter]
@@ -179,7 +186,7 @@ namespace MatBlazor
         {
             if (Link != null)
             {
-                UriHelper.NavigateTo(Link);
+                UriHelper.NavigateTo(Link, ForceLoad);
             }
             else
             {

--- a/src/MatBlazor/Components/MatIconButton/BaseMatIconButton.cs
+++ b/src/MatBlazor/Components/MatIconButton/BaseMatIconButton.cs
@@ -54,6 +54,13 @@ namespace MatBlazor
         public string Link { get; set; }
 
         /// <summary>
+        /// Force browser to redirect outside component router-space.
+        /// </summary>
+        /// 
+        [Parameter]
+        public bool ForceLoad { get; set; }
+
+        /// <summary>
         /// Button is disabled.
         /// </summary>
         [Parameter]
@@ -107,7 +114,7 @@ namespace MatBlazor
 
             if (Link != null)
             {
-                UriHelper.NavigateTo(Link);
+                UriHelper.NavigateTo(Link, ForceLoad);
             }
             else
             {

--- a/src/MatBlazor/MatBlazor.xml
+++ b/src/MatBlazor/MatBlazor.xml
@@ -175,6 +175,12 @@
             Link to a url when clicked.
             </summary>
         </member>
+        <member name="P:MatBlazor.BaseMatButton.ForceLoad">
+            <summary>
+            Force browser to redirect outside component router-space.
+            </summary>
+            
+        </member>
         <member name="P:MatBlazor.BaseMatButton.Raised">
             <summary>
             Button has raised style.
@@ -304,6 +310,12 @@
             <summary>
             Navigate to this url when clicked.
             </summary>
+        </member>
+        <member name="P:MatBlazor.BaseMatIconButton.ForceLoad">
+            <summary>
+            Force browser to redirect outside component router-space.
+            </summary>
+            
         </member>
         <member name="P:MatBlazor.BaseMatIconButton.Disabled">
             <summary>


### PR DESCRIPTION
Came into a problem yesterday where Link option would not work with authentication.
Example links:
"AzureAD/Account/SignOut"
"AzureAD/Account/SignIn"

Then today i found this issue also #330 so i added option on MatButton and MatIconButton to enable ForceLoad for redirects outside component router space and added relevant documentation under each component.