### PR TITLE
Matlist selectedIndex default value set to -1

### DIFF
--- a/src/MatBlazor/Components/MatList/BaseMatList.cs
+++ b/src/MatBlazor/Components/MatList/BaseMatList.cs
@@ -8,7 +8,7 @@ namespace MatBlazor
     /// </summary>
     public class BaseMatList : BaseMatDomComponent
     {
-        private int _selectedIndex;
+        private int _selectedIndex = -1;
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }


### PR DESCRIPTION
Initialising `_selectedIndex `to `-1` allows setting the default selected item to the first item in the list. 
Currently `_selectedIndex `is initialised by default to `0`, therefore calling `SetSelectedIndex(0)` does not yield the correct result, because of: `if (_selectedIndex != index)`