### PR TITLE
Prevent circular overflow on MatNumericUpDownField - issue #373

### DIFF
--- a/src/MatBlazor/Core/MatBlazorSwitchTByte.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTByte.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override byte Increase(byte v, byte step, byte max)
         {
-            var v2 = (byte) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (byte)(v + step) : max;
+            return result;
         }
 
         public override byte Decrease(byte v, byte step, byte min)
         {
-            var v2 = (byte) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (byte)(v - step) : min;
+            return result;
         }
 
         public override byte Round(byte v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override byte FromDecimal(decimal v)
         {
-            return (byte) v;
+            return (byte)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTChar.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTChar.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 
 namespace MatBlazor
 {
@@ -7,14 +6,14 @@ namespace MatBlazor
     {
         public override char Increase(char v, char step, char max)
         {
-            var v2 = (char) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (char)(v + step) : max;
+            return result;
         }
 
         public override char Decrease(char v, char step, char min)
         {
-            var v2 = (char) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (char)(v - step) : min;
+            return result;
         }
 
         public override char Round(char v, int dp)
@@ -25,7 +24,7 @@ namespace MatBlazor
         public override char GetMinimum() => char.MinValue;
         public override char GetMaximum() => char.MaxValue;
 
-        public override char GetStep() => (char) 1;
+        public override char GetStep() => (char)1;
 
         public override string FormatValueAsString(char v, string format)
         {
@@ -54,7 +53,7 @@ namespace MatBlazor
 
         public override char FromDecimal(decimal v)
         {
-            return (char) v;
+            return (char)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTInt.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTInt.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override int Increase(int v, int step, int max)
         {
-            var v2 = (int) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? v + step : max;
+            return result;
         }
 
         public override int Decrease(int v, int step, int min)
         {
-            var v2 = (ushort) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? v - step : min;
+            return result;
         }
 
         public override int Round(int v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override int FromDecimal(decimal v)
         {
-            return (int) v;
+            return (int)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTLong.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTLong.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override long Increase(long v, long step, long max)
         {
-            var v2 = (long) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (long)(v + step) : max;
+            return result;
         }
 
         public override long Decrease(long v, long step, long min)
         {
-            var v2 = (long) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (long)(v - step) : min;
+            return result;
         }
 
         public override long Round(long v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override long FromDecimal(decimal v)
         {
-            return (long) v;
+            return (long)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTSByte.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTSByte.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override sbyte Increase(sbyte v, sbyte step, sbyte max)
         {
-            var v2 = (sbyte) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (sbyte)(v + step) : max;
+            return result;
         }
 
         public override sbyte Decrease(sbyte v, sbyte step, sbyte min)
         {
-            var v2 = (sbyte) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (sbyte)(v - step) : min;
+            return result;
         }
 
         public override sbyte Round(sbyte v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override sbyte FromDecimal(decimal v)
         {
-            return (sbyte) v;
+            return (sbyte)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTShort.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTShort.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override short Increase(short v, short step, short max)
         {
-            var v2 = (short) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (short)(v + step) : max;
+            return result;
         }
 
         public override short Decrease(short v, short step, short min)
         {
-            var v2 = (short) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (short)(v - step) : min;
+            return result;
         }
 
         public override short Round(short v, int dp)
@@ -53,7 +53,7 @@ namespace MatBlazor
 
         public override short FromDecimal(decimal v)
         {
-            return (short) v;
+            return (short)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTUInt.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTUInt.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override uint Increase(uint v, uint step, uint max)
         {
-            var v2 = (uint) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? v + step : max;
+            return result;
         }
 
         public override uint Decrease(uint v, uint step, uint min)
         {
-            var v2 = (uint) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? v - step : min;
+            return result;
         }
 
         public override uint Round(uint v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override uint FromDecimal(decimal v)
         {
-            return (uint) v;
+            return (uint)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTULong.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTULong.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override ulong Increase(ulong v, ulong step, ulong max)
         {
-            var v2 = (ulong) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (ulong)(v + step) : max;
+            return result;
         }
 
         public override ulong Decrease(ulong v, ulong step, ulong min)
         {
-            var v2 = (ulong) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (ulong)(v - step) : min;
+            return result;
         }
 
         public override ulong Round(ulong v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override ulong FromDecimal(decimal v)
         {
-            return (ulong) v;
+            return (ulong)v;
         }
     }
 }

--- a/src/MatBlazor/Core/MatBlazorSwitchTUShort.cs
+++ b/src/MatBlazor/Core/MatBlazorSwitchTUShort.cs
@@ -7,14 +7,14 @@ namespace MatBlazor
     {
         public override ushort Increase(ushort v, ushort step, ushort max)
         {
-            var v2 = (ushort) (v + step);
-            return v2 <= max ? v2 : max;
+            var result = (v <= max - step) ? (ushort)(v + step) : max;
+            return result;
         }
 
         public override ushort Decrease(ushort v, ushort step, ushort min)
         {
-            var v2 = (ushort) (v - step);
-            return v2 >= min ? v2 : min;
+            var result = (v >= min + step) ? (ushort)(v - step) : min;
+            return result;
         }
 
         public override ushort Round(ushort v, int dp)
@@ -54,7 +54,7 @@ namespace MatBlazor
 
         public override ushort FromDecimal(decimal v)
         {
-            return (ushort) v;
+            return (ushort)v;
         }
     }
 }


### PR DESCRIPTION
I corrected a small issue making the NumericDropDown making overflow.