### PR TITLE
Fix #393, Fix #319, MatNavItem still clickable when disabled=true. Add OnClick to MatNavItem

### DIFF
--- a/src/MatBlazor.Demo/Demo/DemoMatNavMenu.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatNavMenu.razor
@@ -6,7 +6,7 @@
         @using Microsoft.AspNetCore.Components
 
         <MatNavMenu>
-            <MatNavItem>Item 1</MatNavItem>
+            <MatNavItem OnClick="ClickMe">Item 1 - OnClick</MatNavItem>
             <MatNavItem Disabled="true">Item 2</MatNavItem>
             <MatNavSubMenu @bind-Expanded="@navSubMenuOpenState">
                 <MatNavSubMenuHeader>
@@ -31,14 +31,22 @@
                     <MatNavItem>Item 6.C</MatNavItem>
                 </MatNavSubMenuList>
             </MatNavSubMenu>
-            <MatNavItem Href="https://blazorboilerplate.com/">Blazor Boilerplate</MatNavItem>
-            <MatNavItem Href="https://www.matblazor.com/">MatBlazor</MatNavItem>
+            <MatNavItem Href="https://blazorboilerplate.com/">Blazor Boilerplate - Href</MatNavItem>
+            <MatNavItem Href="https://www.matblazor.com/">MatBlazor - Href</MatNavItem>
         </MatNavMenu>
 
 
         @code
         {
+            [Inject] IJSRuntime JS { get; set; }
+
             bool navSubMenuOpenState;
+
+            async Task ClickMe()
+            {
+                Console.WriteLine("test");
+                await JS.InvokeAsync<object>("alert", "Successful OnClick!");
+            }
         }
 
     </Content>
@@ -47,7 +55,7 @@
         @using Microsoft.AspNetCore.Components
 
         <MatNavMenu>
-            <MatNavItem>Item 1</MatNavItem>
+            <MatNavItem OnClick=""ClickMe"">Item 1 - OnClick</MatNavItem>
             <MatNavItem Disabled=""true"">Item 2</MatNavItem>
             <MatNavSubMenu @bind-Expanded=""@navSubMenuOpenState"">
                 <MatNavSubMenuHeader>
@@ -72,14 +80,18 @@
                     <MatNavItem>Item 6.C</MatNavItem>
                 </MatNavSubMenuList>
             </MatNavSubMenu>
-            <MatNavItem Href=""https://blazorboilerplate.com/"">Blazor Boilerplate</MatNavItem>
-            <MatNavItem Href=""https://www.matblazor.com/"">MatBlazor</MatNavItem>
+            <MatNavItem Href=""https://blazorboilerplate.com/"">Blazor Boilerplate  - Href</MatNavItem>
+            <MatNavItem Href=""https://www.matblazor.com/"">MatBlazor  - Href</MatNavItem>
         </MatNavMenu>
 
 
         @code
         {
+            [Inject] IJSRuntime JS { get; set; }
             bool navSubMenuOpenState;
+
+            async Task ClickMe() =>
+                await JS.InvokeAsync<object>(""alert"", ""Successful OnClick!"");
         }
 
     ")></BlazorFiddle>

--- a/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
+++ b/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
@@ -61,7 +61,7 @@
     protected async override Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-   
+
         var groups = new
         {
             FormControls = new NavGroup("Form Controls", 1),
@@ -79,7 +79,7 @@
                 Url = "EditContext",
                 Group = groups.FormControls,
                 Order = 1
-            },            
+            },
 //            new NavItem()
 //            {
 //                Name = "Autocomplete",

--- a/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
+++ b/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
@@ -1,6 +1,7 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace MatBlazor
 {
@@ -18,6 +19,18 @@ namespace MatBlazor
         [CascadingParameter]
         public BaseMatNavSubMenu MatNavSubMenu { get; set; }
 
+        /// <summary>
+        ///  Command executed when the user clicks on an element.
+        /// </summary>
+        [Parameter]
+        public ICommand Command { get; set; }
+
+        /// <summary>
+        ///  Command parameter.
+        /// </summary>
+        [Parameter]
+        public object CommandParameter { get; set; }
+
         [Parameter]
         public bool Selected { get; set; }
 
@@ -30,7 +43,7 @@ namespace MatBlazor
         public async Task ToggleSelectedAsync()
         {
             this.Selected = !this.Selected;
-            
+
             await SelectedChanged.InvokeAsync(this.Selected);
 
             if (MatNavMenu != null)
@@ -48,16 +61,29 @@ namespace MatBlazor
                 .If("mdc-list-item--selected", () => Selected);
         }
 
+        /// <summary>
+        ///  OnClickHandler parameter.
+        /// </summary>
         protected async void OnClickHandler(MouseEventArgs e)
         {
+            if (Disabled) return;
+
             if (AllowSelection)
             {
                 await this.ToggleSelectedAsync();
             }
 
-            if (Href != null && !Disabled)
+            if (Href != null)
             {
                 UriHelper.NavigateTo(Href);
+            }
+            else
+            {
+                await OnClick.InvokeAsync(e);
+                //if (Command?.CanExecute(CommandParameter) ?? false)
+                //{
+                //    Command.Execute(CommandParameter);
+                //}
             }
         }
     }

--- a/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
+++ b/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
@@ -34,6 +34,9 @@ namespace MatBlazor
         [Parameter]
         public bool Selected { get; set; }
 
+        /// <summary>
+        /// Specifies weather you the Nav Item can be selected / active.
+        /// </summary>
         [Parameter]
         public bool AllowSelection { get; set; } = true;
 
@@ -58,7 +61,7 @@ namespace MatBlazor
         {
             ClassMapper
                 .Add("mdc-nav-item")
-                .If("mdc-list-item--selected", () => Selected);
+                .If("mdc-list-item--selected", () => (Selected && AllowSelection));
         }
 
         /// <summary>
@@ -80,10 +83,10 @@ namespace MatBlazor
             else
             {
                 await OnClick.InvokeAsync(e);
-                //if (Command?.CanExecute(CommandParameter) ?? false)
-                //{
-                //    Command.Execute(CommandParameter);
-                //}
+                if (Command?.CanExecute(CommandParameter) ?? false)
+                {
+                    Command.Execute(CommandParameter);
+                }
             }
         }
     }

--- a/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
+++ b/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
@@ -4,7 +4,7 @@
 
     <CascadingValue Value="@this">
 
-        @if (string.IsNullOrEmpty(Href))
+        @if (string.IsNullOrEmpty(Href) || @Disabled)
         {
             <li class="@ClassMapper.AsString()" @onmousedown="OnMouseDown" style="@StyleMapper.AsString()" @ref="Ref" @attributes="Attributes" Id="@Id">
                 @ChildContent

--- a/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
+++ b/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
@@ -4,14 +4,14 @@
 
     <CascadingValue Value="@this">
 
-        @if (string.IsNullOrEmpty(Href) || @Disabled)
+        @if (@Disabled)
         {
             <li class="@ClassMapper.AsString()" @onmousedown="OnMouseDown" style="@StyleMapper.AsString()" @ref="Ref" @attributes="Attributes" Id="@Id">
                 @ChildContent
             </li>
         }
-        else
-        {
+        else 
+        { 
             <li class="mdc-nav-li" @ref="Ref" @attributes="Attributes" Id="@Id">
                 <NavLink class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" href="@Href" @onclick="OnClickHandler" Match="NavLinkMatch.All" ActiveClass="mdc-list-item--selected">
                     @ChildContent

--- a/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
+++ b/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
@@ -2,21 +2,21 @@
 @using Microsoft.AspNetCore.Components.Routing;
 @inherits BaseMatNavItem
 
-    <CascadingValue Value="@this">
+<CascadingValue Value="@this">
 
-        @if (@Disabled)
-        {
-            <li class="@ClassMapper.AsString()" @onmousedown="OnMouseDown" style="@StyleMapper.AsString()" @ref="Ref" @attributes="Attributes" Id="@Id">
+    @if (string.IsNullOrEmpty(Href) || Disabled)
+    {
+        <li class="@ClassMapper.AsString()" @onmousedown="OnMouseDown" style="@StyleMapper.AsString()" @ref="Ref" @attributes="Attributes" Id="@Id" @onclick="OnClickHandler">
+            @ChildContent
+        </li>
+    }
+    else
+    {
+        <li class="mdc-nav-li" @ref="Ref" @attributes="Attributes" Id="@Id">
+            <NavLink class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" href="@Href" @onclick="OnClickHandler" Match="NavLinkMatch.All" ActiveClass="mdc-list-item--selected">
                 @ChildContent
-            </li>
-        }
-        else 
-        { 
-            <li class="mdc-nav-li" @ref="Ref" @attributes="Attributes" Id="@Id">
-                <NavLink class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" href="@Href" @onclick="OnClickHandler" Match="NavLinkMatch.All" ActiveClass="mdc-list-item--selected">
-                    @ChildContent
-                </NavLink>
-            </li>
-        }
+            </NavLink>
+        </li>
+    }
 
-    </CascadingValue>
+</CascadingValue>

--- a/src/MatBlazor/MatBlazor.xml
+++ b/src/MatBlazor/MatBlazor.xml
@@ -420,6 +420,16 @@
             Nav Item is a menu item in the Nav Menu. Inherits from Mat List Item.
             </summary>
         </member>
+        <member name="P:MatBlazor.BaseMatNavItem.Selected">
+            <summary>
+             Command parameter.
+            </summary>
+        </member>
+        <member name="M:MatBlazor.BaseMatNavItem.OnClickHandler(Microsoft.AspNetCore.Components.Web.MouseEventArgs)">
+            <summary>
+             OnClick Handler parameter.
+            </summary>
+        </member>
         <member name="T:MatBlazor.BaseMatNavMenu">
             <summary>
             MatNavMenu provides a navigation container


### PR DESCRIPTION
- Fix for #393, Fixes MatNavItem so that if Disabled=true it will not redirect. 
- Fix for #319 Additionally this adds an OnClick Functionality to the MatNavItem so you can do a custom method if a redirect is not what you want to do.
