### PR TITLE
Added ability to hide toggle button in MatAccordion / MatExpansionpanel

### DIFF
--- a/src/MatBlazor.Demo/Doc/DocMatAccordion.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAccordion.razor
@@ -28,6 +28,11 @@
 		<td>Specifies one or more classnames for an DOM element.</td>
 	</tr>
 	<tr>
+		<td>HideToggle</td>
+		<td>Boolean</td>
+		<td>Hides toggle icon for all expansion panel summaries in the accordion</td>
+	</tr>
+	<tr>
 		<td>Id</td>
 		<td>String</td>
 		<td></td>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanel.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanel.razor
@@ -40,6 +40,11 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>HideToggle</td>
+		<td>Boolean</td>
+		<td>Hides the toggle icon in the expansion panel summary</td>
+	</tr>
+	<tr>
 		<td>Id</td>
 		<td>String</td>
 		<td></td>

--- a/src/MatBlazor/Components/MatAccordion/BaseMatAccordion.cs
+++ b/src/MatBlazor/Components/MatAccordion/BaseMatAccordion.cs
@@ -11,6 +11,12 @@ namespace MatBlazor
         [Parameter]
         public bool Multi { get; set; }
 
+        /// <summary>
+        /// Hides toggle icon for all expansion panel summaries in the accordion
+        /// </summary>
+        [Parameter]
+        public bool HideToggle { get; set; }
+
         public BaseMatExpansionPanel Current { get; private set; }
 
         public async Task ToggleAsync(BaseMatExpansionPanel panel)

--- a/src/MatBlazor/Components/MatAccordion/BaseMatExpansionPanel.cs
+++ b/src/MatBlazor/Components/MatAccordion/BaseMatExpansionPanel.cs
@@ -17,6 +17,12 @@ namespace MatBlazor
         [Parameter]
         public bool Expanded { get; set; }
 
+        /// <summary>
+        /// Hides the toggle icon in the expansion panel summary
+        /// </summary>
+        [Parameter]
+        public bool HideToggle { get; set; }
+
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
 
@@ -34,6 +40,8 @@ namespace MatBlazor
                 .Add("mat-expansion-panel")
                 .Add("mdc-elevation--z3")
                 .If("mat-expansion-panel--expanded", () => Expanded);
+
+            HideToggle = HideToggle || (Accordion?.HideToggle ?? false);
         }
     }
 }

--- a/src/MatBlazor/Components/MatAccordion/MatExpansionPanelSummary.razor
+++ b/src/MatBlazor/Components/MatAccordion/MatExpansionPanelSummary.razor
@@ -3,10 +3,13 @@
 @inherits BaseMatDomComponent
 
 
-<div class="@ClassMapper.AsString()" @ref="Ref"  style="@StyleMapper.AsString()" @onclick="OnClickHandler" @attributes="Attributes" Id="@Id">
+<div class="@ClassMapper.AsString()" @ref="Ref" style="@StyleMapper.AsString()" @onclick="OnClickHandler" @attributes="Attributes" Id="@Id">
     @ChildContent
 
-    <span class="after material-icon">&#58131;</span>
+    @if (!ExpansionPanel.HideToggle)
+    {
+        <span class="after material-icon">&#58131;</span>
+    }
 </div>
 
 @code

--- a/src/MatBlazor/MatBlazor.xml
+++ b/src/MatBlazor/MatBlazor.xml
@@ -94,9 +94,19 @@
             <param name="validationErrorMessage">If the value could not be parsed, provides a validation error message.</param>
             <returns>True if the value could be parsed; otherwise false.</returns>
         </member>
+        <member name="P:MatBlazor.BaseMatAccordion.HideToggle">
+            <summary>
+            Hides toggle icon for all expansion panel summaries in the accordion
+            </summary>
+        </member>
         <member name="T:MatBlazor.BaseMatExpansionPanel">
             <summary>
             MatExpansionPanel provides an expandable details-summary view.
+            </summary>
+        </member>
+        <member name="P:MatBlazor.BaseMatExpansionPanel.HideToggle">
+            <summary>
+            Hides the toggle icon in the expansion panel summary
             </summary>
         </member>
         <member name="T:MatBlazor.BaseMatAppBar">


### PR DESCRIPTION
Hello!

First of all, thank you for your great work with this repository. I'm looking forward to use MatBlazor in upcoming Blazor projects!

I've added the ability to be able to hide the toggle button in MatAccordion and MatExpansionpanel similar to how Angular has done in their implementation of Material. With this change you can get a cleaner accordion in some cases when you don't want the arrow in the summary. See Angular stackblitz example below (From their docs)

https://stackblitz.com/angular/qkjarbvydory?file=src%2Fapp%2Fexpansion-steps-example.ts

I added some XML comments for the parameters and ran the DevUtils before committing, I hope everything is in order - if not please reply.

Best regards
Victor Lindespång
