### PR TITLE
#455 - Add Parameter to MatNavItem to allow user to set the NavLinkMatch

### DIFF
--- a/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
+++ b/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
@@ -5,7 +5,7 @@
 </style>
 
 <MatNavMenu Multi="true">
-    <MatNavItem Href="@Url.ToAbsoluteUri("").AbsoluteUri"><MatIcon Icon="home"></MatIcon>&nbsp; Home</MatNavItem>
+    <MatNavItem Href="@Url.ToAbsoluteUri("").AbsoluteUri" NavLinkMatch="NavLinkMatch.All"><MatIcon Icon="home"></MatIcon>&nbsp; Home</MatNavItem>
 
     @foreach (var groupModel in model)
     {

--- a/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
+++ b/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -33,6 +34,12 @@ namespace MatBlazor
 
         [Parameter]
         public bool Selected { get; set; }
+
+        /// <summary>
+        ///  NavLinkMatch parameter used to determine the active state of the Nav Item.
+        /// </summary>
+        [Parameter]
+        public NavLinkMatch NavLinkMatch { get; set; } = NavLinkMatch.Prefix;
 
         /// <summary>
         /// Specifies weather you the Nav Item can be selected / active.

--- a/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
+++ b/src/MatBlazor/Components/MatNavMenu/MatNavItem.razor
@@ -13,7 +13,7 @@
     else
     {
         <li class="mdc-nav-li" @ref="Ref" @attributes="Attributes" Id="@Id">
-            <NavLink class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" href="@Href" @onclick="OnClickHandler" Match="NavLinkMatch.Prefix" ActiveClass="mdc-list-item--selected">
+            <NavLink class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" href="@Href" @onclick="OnClickHandler" Match="@NavLinkMatch" ActiveClass="mdc-list-item--selected">
                 @ChildContent
             </NavLink>
         </li>

--- a/src/MatBlazor/MatBlazor.xml
+++ b/src/MatBlazor/MatBlazor.xml
@@ -430,6 +430,11 @@
              Command parameter.
             </summary>
         </member>
+        <member name="P:MatBlazor.BaseMatNavItem.NavLinkMatch">
+            <summary>
+             NavLinkMatch parameter used to determine the active state of the Nav Item.
+            </summary>
+        </member>
         <member name="P:MatBlazor.BaseMatNavItem.AllowSelection">
             <summary>
             Specifies weather you the Nav Item can be selected / active.


### PR DESCRIPTION
Fixes Home / root always active even when not on the / path.