### PR TITLE
[#479] Remove node-sass and add temporary workaround for sass-loader.

### DIFF
--- a/src/MatBlazor.Web/package.json
+++ b/src/MatBlazor.Web/package.json
@@ -71,7 +71,6 @@
     "json-loader": "^0.5.7",
     "license-webpack-plugin": "^2.1.3",
     "mini-css-extract-plugin": "^0.9.0",
-    "node-sass": "^4.13.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-loader": "^3.0.0",
     "sass": "^1.26.0",

--- a/src/MatBlazor.Web/webpack/prod.config.js
+++ b/src/MatBlazor.Web/webpack/prod.config.js
@@ -53,6 +53,7 @@ module.exports = {
           {
             loader: "sass-loader", // compiles Sass to CSS
             options: {
+              webpackImporter: false, // Recommended temporary workaround until https://github.com/webpack-contrib/sass-loader/issues/804 is fixed
               sassOptions: {
                 "includePaths": [
                   path.resolve(__dirname, '../node_modules')


### PR DESCRIPTION
- Source1 (remove node-sass): https://github.com/material-components/material-components-web/issues/5502#issuecomment-586061492
- Source2 (temporary workaround): https://github.com/webpack-contrib/sass-loader/issues/804#issuecomment-586095020

https://github.com/SamProf/MatBlazor/issues/479