### PR TITLE
[#477] Use height instead of max-height in mat-expansion-panel base/expanded

### DIFF
--- a/src/MatBlazor.Web/src/matAccordion/matAccordion.scss
+++ b/src/MatBlazor.Web/src/matAccordion/matAccordion.scss
@@ -3,19 +3,19 @@
     > .mat-expansion-panel__content, .mat-expansion-panel__actions
     {
       display: none;
-      max-height: 0;
       opacity: 0;
       overflow: hidden;
       transition: all .4s ease-in-out;
+      height: 0;
     }
 
     &.mat-expansion-panel--expanded
     {
       > .mat-expansion-panel__content, .mat-expansion-panel__actions
       {
-        max-height: 1000px;
         opacity: 1;
         display: block;
+        height: auto;
       }
     }
 


### PR DESCRIPTION
- This fixes problems with contents that have over 1000px height
- Same solution is used in material-ui's Collapse https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Collapse/Collapse.js

https://github.com/SamProf/MatBlazor/issues/477