### PR TITLE
Added label color to theme primary color

### DIFF
--- a/src/MatBlazor.Web/src/matTextField/matTextField.scss
+++ b/src/MatBlazor.Web/src/matTextField/matTextField.scss
@@ -63,6 +63,11 @@ div.mdc-text-field--fullwidth-with-leading-icon:not(.mdc-text-field--textarea) >
   font-size: 0.9rem;
 }
 
+/* Label color to theme primary color */
+.mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+    color: var(--mdc-theme-primary, #6200ee);
+}
+
 /* For DatePicker */
 .valid.modified > .mdc-text-field__input {
   border-bottom: 2px solid #10b510 !important;


### PR DESCRIPTION
Added style to change label color to use theme's primary color.

Material design have this default value for the label

    .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
        color: rgba(98,0,238,0.87);
    }

So I just changed to use the theme primary color

    .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
        color: var(--mdc-theme-primary, #6200ee);
    }

The result is

![mat-textfield-label-color](https://user-images.githubusercontent.com/37600269/78557119-9ab5a380-77e6-11ea-9783-0c7fb5937879.gif)

The only problem is that I **haven't test it when building the application**, only edit in the browser to test it.

So before merging, **please build the app and test this**.

My concern is that the css won't override the `mdc` classes. 