### PR TITLE
Enables multiple file upload on MatFileInput component

### DIFF
--- a/src/MatBlazor/Components/MatFileUpload/BaseMatFileUpload.cs
+++ b/src/MatBlazor/Components/MatFileUpload/BaseMatFileUpload.cs
@@ -17,6 +17,9 @@ namespace MatBlazor
         public EventCallback<IMatFileUploadEntry[]> OnChange { get; set; }
 
         [Parameter]
+        public bool AllowMultiple { get; set; } = false; 
+
+        [Parameter]
         public string Label { get; set; } = "Drop files here or Browse";
 
         [Parameter]

--- a/src/MatBlazor/Components/MatFileUpload/MatFileUpload.razor
+++ b/src/MatBlazor/Components/MatFileUpload/MatFileUpload.razor
@@ -2,13 +2,18 @@
 @inherits BaseMatFileUpload
 
 <div @ref="@Ref" @attributes="@Attributes" class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" id="@Id">
-    <input type="file" @ref="@InputRef" multiple/>
+    @if (AllowMultiple == true){
+        <input type="file" @ref="@InputRef" multiple />
+    }
+    else {
+        <input type="file" @ref="@InputRef" />
+    }
     <div class="mat-file-upload-content">
         <span>@Label</span>
         <MatIcon>@MatIconNames.Attach_file</MatIcon>
     </div>
     @if (ProgressTotal != 0)
     {
-        <MatProgressBar Class="mat-file-upload-progress" Progress="@(Math.Round((double)ProgressProgress / ProgressTotal, 2))"></MatProgressBar>
+    <MatProgressBar Class="mat-file-upload-progress" Progress="@(Math.Round((double)ProgressProgress / ProgressTotal, 2))"></MatProgressBar>
     }
 </div>

--- a/src/MatBlazor/Components/MatFileUpload/MatFileUpload.razor
+++ b/src/MatBlazor/Components/MatFileUpload/MatFileUpload.razor
@@ -2,7 +2,7 @@
 @inherits BaseMatFileUpload
 
 <div @ref="@Ref" @attributes="@Attributes" class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" id="@Id">
-    <input type="file" @ref="@InputRef"/>
+    <input type="file" @ref="@InputRef" multiple/>
     <div class="mat-file-upload-content">
         <span>@Label</span>
         <MatIcon>@MatIconNames.Attach_file</MatIcon>


### PR DESCRIPTION
The documentation for MatFileInput gives an example of being able to select or drop multiple files into the component for processing. The component currently only allows single file selection. This change enables the multiple file selection/drop into the component.