### PR TITLE
Fixed #545 Can't select item in MatAutocompleteList 

### DIFF
--- a/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
+++ b/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
@@ -91,7 +91,7 @@ namespace MatBlazor
             set
             {
                 var newerStringValue = EqualValues(value, default) ? string.Empty : ComputeStringValue(value);
-                if(newerStringValue != StringValue)
+                if (newerStringValue != StringValue)
                 {
                     StringValue = newerStringValue;
                 }
@@ -226,11 +226,5 @@ namespace MatBlazor
         {
             return CustomStringSelector?.Invoke(obj) ?? obj?.ToString();
         }
-
-        //        protected async override Task OnFirstAfterRenderAsync()
-        //        {
-        //            await base.OnFirstAfterRenderAsync();
-        //            await JsInvokeAsync<object>("matBlazor.matAutocomplete.init", Ref);
-        //        }
     }
 }

--- a/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
+++ b/src/MatBlazor/Components/MatAutocompleteList/BaseMatAutocompleteList.cs
@@ -90,13 +90,18 @@ namespace MatBlazor
             get { return _value; }
             set
             {
+                var newerStringValue = EqualValues(value, default) ? string.Empty : ComputeStringValue(value);
+                if(newerStringValue != StringValue)
+                {
+                    StringValue = newerStringValue;
+                }
+
                 if (EqualValues(value, _value))
                 {
                     return;
                 }
 
                 _value = value;
-                StringValue = EqualValues(Value, default(TItem)) ? string.Empty : ComputeStringValue(Value);
                 ValueChanged.InvokeAsync(_value);
             }
         }
@@ -167,6 +172,10 @@ namespace MatBlazor
 
         protected void ClosePopup()
         {
+            if (StringValue != ComputeStringValue(Value))
+            {
+                _value = default;
+            }
             IsOpened = false;
         }
 
@@ -218,10 +227,10 @@ namespace MatBlazor
             return CustomStringSelector?.Invoke(obj) ?? obj?.ToString();
         }
 
-//        protected async override Task OnFirstAfterRenderAsync()
-//        {
-//            await base.OnFirstAfterRenderAsync();
-//            await JsInvokeAsync<object>("matBlazor.matAutocomplete.init", Ref);
-//        }
+        //        protected async override Task OnFirstAfterRenderAsync()
+        //        {
+        //            await base.OnFirstAfterRenderAsync();
+        //            await JsInvokeAsync<object>("matBlazor.matAutocomplete.init", Ref);
+        //        }
     }
 }


### PR DESCRIPTION
I fixed it to update the Value when closing the dialog(to not keep old references which are no longer represented by the StringValue + When changing the value, even if the value will be the same it is possible to need to update the StringValue:

e.g. Select One, delete e, Select One.