### PR TITLE
Fix typo in MatSelect demos

### DIFF
--- a/src/MatBlazor.Demo/Demo/DemoMatSelectItem.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatSelectItem.razor
@@ -7,7 +7,7 @@
 <DemoContainer>
     <Content>
         <p>
-            <MatSelectItem @bind-Value="@value1" Items="@vlaue1Items"></MatSelectItem>
+            <MatSelectItem @bind-Value="@value1" Items="@value1Items"></MatSelectItem>
         </p>
         <p>
             Selected value: @value1
@@ -18,7 +18,7 @@
         {
             string value1 = "Grains";
 
-            string[] vlaue1Items = new[]
+            string[] value1Items = new[]
             {
                 "Grains",
                 "Vegetables",
@@ -31,7 +31,7 @@
     <SourceContent>
     	<BlazorFiddle Template="MatBlazor" Code=@(@"
         <p>
-            <MatSelectItem @bind-Value=""@value1"" Items=""@vlaue1Items""></MatSelectItem>
+            <MatSelectItem @bind-Value=""@value1"" Items=""@value1Items""></MatSelectItem>
         </p>
         <p>
             Selected value: @value1
@@ -42,7 +42,7 @@
         {
             string value1 = ""Grains"";
 
-            string[] vlaue1Items = new[]
+            string[] value1Items = new[]
             {
                 ""Grains"",
                 ""Vegetables"",
@@ -171,7 +171,7 @@
 
     </Content>
     <SourceContent>
-    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <BlazorFiddle Template="MatBlazor" Code=@(@"
         <MatSelectItem @bind-Value=""value2"" Items=""@value2Items"">
         </MatSelectItem>
 

--- a/src/MatBlazor.Demo/Demo/DemoMatSelectValue.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatSelectValue.razor
@@ -1,7 +1,7 @@
 <DocMatSelectValue></DocMatSelectValue>
 
 
-<MatH5>Example MatSelectVlaue with class array and ItemTemplate</MatH5>
+<MatH5>Example MatSelectValue with class array and ItemTemplate</MatH5>
 
 <DemoContainer>
     <Content>
@@ -96,7 +96,7 @@
 <DemoContainer>
     <Content>
         <p>
-            <MatSelectValue @bind-Value="@value1" Items="@vlaue1Items" ValueSelector=@(i=>i.ToString())></MatSelectValue>
+            <MatSelectValue @bind-Value="@value1" Items="@value1Items" ValueSelector=@(i=>i.ToString())></MatSelectValue>
         </p>
         <p>
             Selected value: @value1
@@ -107,7 +107,7 @@
         {
             string value1 = "2";
 
-            int[] vlaue1Items = new[]
+            int[] value1Items = new[]
             {
                 1,
                 2,
@@ -122,7 +122,7 @@
     <SourceContent>
     	<BlazorFiddle Template="MatBlazor" Code=@(@"
         <p>
-            <MatSelectValue @bind-Value=""@value1"" Items=""@vlaue1Items"" ValueSelector=@(i=>i.ToString())></MatSelectValue>
+            <MatSelectValue @bind-Value=""@value1"" Items=""@value1Items"" ValueSelector=@(i=>i.ToString())></MatSelectValue>
         </p>
         <p>
             Selected value: @value1
@@ -133,7 +133,7 @@
         {
             string value1 = ""2"";
 
-            int[] vlaue1Items = new[]
+            int[] value1Items = new[]
             {
                 1,
                 2,


### PR DESCRIPTION
* fixes typos "vlaue" -> "value" in the follwing demos
  * DemoMatSelectItem
  * DemoMatSelectValue
