### PR TITLE
Added lazy rendering for matexpansionpanel details + bug fix

### DIFF
--- a/src/MatBlazor/Components/MatAccordion/BaseMatAccordion.cs
+++ b/src/MatBlazor/Components/MatAccordion/BaseMatAccordion.cs
@@ -17,6 +17,12 @@ namespace MatBlazor
         [Parameter]
         public bool HideToggle { get; set; }
 
+        /// <summary>
+        /// Enables lazy rendering for all expansion panel details in the accordion.
+        /// </summary>
+        [Parameter]
+        public bool LazyRendering { get; set; }
+
         public BaseMatExpansionPanel Current { get; private set; }
 
         public async Task ToggleAsync(BaseMatExpansionPanel panel)

--- a/src/MatBlazor/Components/MatAccordion/BaseMatExpansionPanel.cs
+++ b/src/MatBlazor/Components/MatAccordion/BaseMatExpansionPanel.cs
@@ -23,6 +23,12 @@ namespace MatBlazor
         [Parameter]
         public bool HideToggle { get; set; }
 
+        /// <summary>
+        /// Enables lazy rendering of the expansion panel details.
+        /// </summary>
+        [Parameter]
+        public bool LazyRendering { get; set; }
+
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
 
@@ -39,9 +45,13 @@ namespace MatBlazor
             ClassMapper
                 .Add("mat-expansion-panel")
                 .Add("mdc-elevation--z3")
-                .If("mat-expansion-panel--expanded", () => Expanded);
+                .If("mat-expansion-panel--expanded", () => Expanded);           
+        }
 
+        protected override void OnInitialized()
+        {
             HideToggle = HideToggle || (Accordion?.HideToggle ?? false);
+            LazyRendering = LazyRendering || (Accordion?.LazyRendering ?? false);
         }
     }
 }

--- a/src/MatBlazor/Components/MatAccordion/MatExpansionPanelDetails.razor
+++ b/src/MatBlazor/Components/MatAccordion/MatExpansionPanelDetails.razor
@@ -2,14 +2,21 @@
 @using Microsoft.AspNetCore.Components
 @inherits BaseMatDomComponent
 
-<div class="@ClassMapper.AsString() mat-expansion-panel__content" style="@StyleMapper.AsString()" @ref="Ref"  @attributes="Attributes" Id="@Id">
-    @ChildContent
-</div>
+@if(!ExpansionPanel.LazyRendering || ExpansionPanel.Expanded)
+{
+    <div class="@ClassMapper.AsString() mat-expansion-panel__content" style="@StyleMapper.AsString()" @ref="Ref" @attributes="Attributes" Id="@Id">
+        @ChildContent
+    </div>
+}
+
 
 @code
 {
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }
+
+    [CascadingParameter]
+    public BaseMatExpansionPanel ExpansionPanel { get; set; }
 
 }


### PR DESCRIPTION
Hi!

Yeah so I was migrating my Blazor server app to webassembly now since the general release a few days ago and I noticed the rendering is quite a lot slower compared to Blazor server (have not played with webassembly before actually) - hopefully this get a big improvement from AOT compilation which is next milestone for blazor webassembly. As of now I have to look into where I can make performance improvements in both my own code and in MatBlazor

_(...which lead up to this pull request)_

First step is that I added the ability of _opt-in_ lazy rendering for the details view in the accordion / expansionpanel - this means that the HTML of the details view is not rendered until you expand the panel. The current behaviour (_which will also continue to be the default behavior_) is that the HTML is rendered but hidden.

For now it's possible for me to do it in my own application by binding to the Expanded property and implementing the lazy rendering myself, but I figured it would be cleaner to expose it as a parameter instead. Angular material also has this for their expansion panel:  https://material.angular.io/components/expansion/overview

I also fixed a bug regarding the HideToggle feature (_expansion panels did not inherit correctly_)