### PR TITLE
MatBlazor.com redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ If you think that this project helped you or your company in any way, you can co
 - [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9XT68N2VKWTPE&source=url)
 - [Patreon](https://www.patreon.com/SamProf)
 
-### Sponsors:
+#### Sponsors:
 - Phil Parkin
 - Patreon: Jay Arrowz
 - Patreon: Rene Zaal
 - Patreon: Stas Levich
 
 
-### Backers:
+#### Backers:
 - Oyvind Habberstad
 - [Victor Lindespång](https://github.com/lindespang)
 - Gate575 Kft
@@ -229,7 +229,7 @@ Also we have official [Contributors team](https://github.com/SamProf/MatBlazor/i
 - PR: added @key attribute to MatTab content #395 (Thanks to [chris1411](https://github.com/chris1411))
 - PR: Matlist selectedIndex default value set to -1 #354 (Thanks to [radutomy](https://github.com/radutomy))
 
-### MatBlazor 2.0.0 (Reinvention MatBlazor Forms)
+#### MatBlazor 2.0.0 (Reinvention MatBlazor Forms)
 - This release contain a lot of breaking changes, sorry for that.
 - The main goal of this release was to unify all components for forms, generic type support, reduction of dependence of JS, active use of OOP and the possibility of more active expansion in the future.
 - Update to .NET Core 3.1 Preview 4
@@ -285,7 +285,7 @@ Also we have official [Contributors team](https://github.com/SamProf/MatBlazor/i
 - `MatBlazorInstall` - removed
 
 
-### MatBlazor 1.10.1
+#### MatBlazor 1.10.1
 - Update to .NET Core 3.1 Preview 1
 - Added an active index to the MatTabGroup and MatTabBar #289 (Thanks to [chris1411](https://github.com/chris1411))
 - Auto-Active MatNatItem #268 (Thanks to [enkodellc](https://github.com/enkodellc))
@@ -294,76 +294,76 @@ Also we have official [Contributors team](https://github.com/SamProf/MatBlazor/i
 - Update BlazorBoilerplate description #299 (Thanks to [enkodellc](https://github.com/enkodellc))
 
 
-### MatBlazor 1.9.0
+#### MatBlazor 1.9.0
 - Update to .NET Core 3.0
 
-### MatBlazor 1.8.0
+#### MatBlazor 1.8.0
 - Update to .NET Core 3.0 RC 1
 
-### MatBlazor 1.7.4
+#### MatBlazor 1.7.4
 - Support arrow keys and Enter in Autocomplete #237 (Thanks to [dga711](https://github.com/dga711))
 - MatDialog: New CanBeClosed property #241 (Thanks to [dga711](https://github.com/dga711))
 - Fix: Enhanced MatSelect throws exception(#231) #242 (Thanks to [aviezzi](https://github.com/aviezzi))
 
-### MatBlazor 1.7.2
+#### MatBlazor 1.7.2
 - PR: Add some padding to toasts #238 (Thanks to [dga711](https://github.com/dga711))
 - PR: AutoComplete list cleaner look #239 (Thanks to [dga711](https://github.com/dga711))
 
-### MatBlazor 1.7.1
+#### MatBlazor 1.7.1
 - Change info in Nuget package
 
-### MatBlazor 1.7.0
+#### MatBlazor 1.7.0
 - Update to .NET Core 3.0 Preview 9
 - PR: Return Toast instance on IMatToaster.Add method #228 (Thanks to [Sebbstar](https://github.com/Sebbstar))
 - PR: Replaced all @functions by @code. #233 (Thanks to [SeppPenner](https://github.com/SeppPenner))
 
 
-### MatBlazor 1.6.4
+#### MatBlazor 1.6.4
 - Fix: MatAutocomplete StringValue clearing #216 (Thanks to [lukblazewicz](https://github.com/lukblazewicz))
 - Fix: MatSelect option list in enhanced mode showing example list #221 (Thanks to [aviezzi](https://github.com/aviezzi))
 
 
-### MatBlazor 1.6.3
+#### MatBlazor 1.6.3
 - MatTable: Fix broken paginator when infinite items selected #202 (Thanks to [dga711](https://github.com/dga711))
 - MatDialog.IsOpenChanged now also fires on open #200 (Thanks to [dga711](https://github.com/dga711)
 
-### MatBlazor 1.6.2
+#### MatBlazor 1.6.2
 - Fixed: MatTooltip: Position inside `<table>` is off #195
 
-### MatBlazor 1.6.1
+#### MatBlazor 1.6.1
 - Check ComponentContext.IsConnected for all Js-Invoke's
     - This should have solved the problem with the `RenderStaticComponentAsync`, but did not.
     - You should use `RenderComponentAsync`, also because in Preview 9 `RenderStaticComponentAsync` will be removed ([https://github.com/aspnet/AspNetCore/issues/12245](https://github.com/aspnet/AspNetCore/issues/12245)).
 - PR: Incorporate validation styling and improve EditContext demo #190 (Thanks to [ebekker](https://github.com/ebekker))
 
-### MatBlazor 1.6.0
+#### MatBlazor 1.6.0
 - Update to .NET Core 3.0 Preview 8
 
-### MatBlazor 1.5.4
+#### MatBlazor 1.5.4
 - Fix of EditContext for MatDatePicker
 
-### MatBlazor 1.5.3
+#### MatBlazor 1.5.3
 - PR: Add flatpickr options to MatDatePicker #182 (Thanks to [djinnet](https://github.com/djinnet))
 - PR: Initial support for EditContext-based validation #178 (Thanks to [ebekker](https://github.com/ebekker))
 
-### MatBlazor 1.5.2
+#### MatBlazor 1.5.2
 - PR: Adding example for nested sub menus and new "toggle all" feature #176 (Thanks to [ebekker](https://github.com/ebekker))
 
-### MatBlazor 1.5.1
+#### MatBlazor 1.5.1
 - PR: Adding support for nested NavSubMenus #174 (Thanks to [ebekker](https://github.com/ebekker))
 
-### MatBlazor 1.5.0
+#### MatBlazor 1.5.0
 - MatCard improvements
 
-### MatBlazor 1.4.1
+#### MatBlazor 1.4.1
 - MatTypography improvements
 
-### MatBlazor 1.4.0
+#### MatBlazor 1.4.0
 - New NavMenu - new component (Thanks to [enkodellc](https://github.com/enkodellc))
 - PR: NumericUpDown to preview7. Fix tabindex #161 (Thanks to [ctrl-alt-d](https://github.com/ctrl-alt-d))
 - PR: Outlined #162 (Thanks to [ctrl-alt-d](https://github.com/ctrl-alt-d))
 
-### MatBlazor 1.3.0
+#### MatBlazor 1.3.0
 - Update to .NET Core 3.0 Preview 7
 - All components supports @Attributes and Id parameter
 - MatDatePicker parameters: Label, Dense, Outlined, Required, Disabled
@@ -379,157 +379,157 @@ Also we have official [Contributors team](https://github.com/SamProf/MatBlazor/i
 - Now we have [MatBlazor - Documentation and demo website - Client Side Blazor](https://samprof.github.io/MatBlazor/)
 - Fixed: Docs site looks to show bug for expansion panel #107
 
-### MatBlazor 1.2.0
+#### MatBlazor 1.2.0
 - .NET Core 3.0.100-preview6-012264
 - MatToast (Thanks to [enkodellc](https://github.com/enkodellc))
 - MatNumericUpDownField (Thanks to [ctrl-alt-d](https://github.com/ctrl-alt-d))
 - PR: MatTable bug where LoadData would throw exception when using Filter #101 (Thanks to [Garderoben](https://github.com/Garderoben))
 
-### MatBlazor 1.1.1
+#### MatBlazor 1.1.1
 - Fixed Clicking on Icon in DatePicker doesn't show the calender selection window. #86 
 
-### MatBlazor 1.1.0
+#### MatBlazor 1.1.0
 - MatHidden
 
-### MatBlazor 1.0.1
+#### MatBlazor 1.0.1
 - Material theme configuration #90 
 
-### MatBlazor 1.0.0
+#### MatBlazor 1.0.0
 - MatAccordion, MatExpansionPanel
 - MatTooltip
 - ForwardRef concept
 
-### MatBlazor 0.9.14
+#### MatBlazor 0.9.14
 - MatFAB - Floating Action Button
 
-### MatBlazor 0.9.13
+#### MatBlazor 0.9.13
 - MatThemeProvider (Themes support)
 - MatAppBarContainer, MatAppBarContent
 - PR: MatNumericUpDownField #78 - early preview (ctrl-alt-d)
 - MatMenu fix (added class and style support)
 
-### MatBlazor 0.9.12
+#### MatBlazor 0.9.12
 - MatDatePicker (alpha)
 - MatTextField ReadOnly
 - MatTextField InputClass and InputStyle
 - MatButton Type, Name, Value #75
 
-### MatBlazor 0.9.11
+#### MatBlazor 0.9.11
 - MatTabGroup and MatTab components
 - MatTabBar and MatTabLabel components
 
-### MatBlazor 0.9.10
+#### MatBlazor 0.9.10
 - Update to ASP.NET Core 3.0.0-preview5-19227-01
 - [https://www.matblazor.com](https://www.matblazor.com) working as server-side Blazor on Linux server
 - Fix MatAutoComplete
 - Minor improvements and changes
 
-### MatBlazor 0.9.9
+#### MatBlazor 0.9.9
 - Demo and documentation [https://www.matblazor.com](https://www.matblazor.com) working as server-side Blazor 
 - `<MatBlazorInstall />` for server-side Blazor is obsolete
 - For server-side Blazor used [EmbeddedBlazorContent](https://github.com/SamProf/EmbeddedBlazorContent) [![NuGet](https://img.shields.io/nuget/v/EmbeddedBlazorContent.svg)](https://www.nuget.org/packages/EmbeddedBlazorContent/)
 
-### MatBlazor 0.9.8
+#### MatBlazor 0.9.8
 - New github path: [https://github.com/SamProf/MatBlazor](https://github.com/SamProf/MatBlazor)
 - New gitter chat: [https://gitter.im/MatBlazor/community](https://gitter.im/MatBlazor/community)
 
-### MatBlazor 0.9.7
+#### MatBlazor 0.9.7
 - Fixed Drawer problem
 
-### MatBlazor 0.9.6
+#### MatBlazor 0.9.6
 - All components in one namespace MatBlazor (only one using directive)
 - PR: Revert back to C# 7.3 #66 (enkodellc)
 
-### MatBlazor 0.9.5
+#### MatBlazor 0.9.5
 - Fixed problem with including *.razor files
 - PR: #63 MatBlazor Logo / .svg / .ico #65 (enkodellc)
 
-### MatBlazor 0.9.4
+#### MatBlazor 0.9.4
 - Now we have Logo (many thanks to [enkodellc](https://github.com/enkodellc))
 - PR: Prevent *.razor files from being packed #64 (IvanJosipovic)
 - Fixed Examples generation
 
-### MatBlazor 0.9.3
+#### MatBlazor 0.9.3
 - Update to Blazor 3.0.0-preview4-19216-03
 - PR: MatTable Table Filter, get data from API #61 (enkodellc, arivera12)
 - PR: Fix Table Navigation Error #60 (enkodellc)
 
-### MatBlazor 0.9.2
+#### MatBlazor 0.9.2
 - PR: MatTable Version 1 #58 (enkodellc, arivera12)
 
-### MatBlazor 0.9.1
+#### MatBlazor 0.9.1
 - PR: Fixed #50 Autocomplete FullWidth + #52 (sandrohanea)
 - PR: MatIconButton Add Functionality, Update Demo #53 (enkodellc)
 - PR: Added documentation for autocomplete + Fixed #56 + changed documentation file path to a relative one(instead of absolut) #57 (sandrohanea)
 
-### MatBlazor 0.9.0
+#### MatBlazor 0.9.0
 - Creating partial documentation for all components (autogeneration)
 - Improved many examples
 - Improved homepage, components page design, README.md
 - Change of versioning policy is similar to Blazor
 - Fixed MatTextBox FullWidth Padding / Icon Fix #43 #51 (enkodellc)
 
-### MatBlazor 0.6.17
+#### MatBlazor 0.6.17
 - Fixed Select is showing native arrow? #48 (sandrohanea)
 
-### MatBlazor 0.6.16
+#### MatBlazor 0.6.16
 - New component MatAutocomplete (sandrohanea)
 
-### New domain name
+#### New domain name
 - [www.matblazor.com](https://www.matblazor.com)
 
-### MatBlazor 0.6.15
+#### MatBlazor 0.6.15
 - New component MatSnackbar
 
-### MatBlazor 0.6.14
+#### MatBlazor 0.6.14
 - New component MatRipple
 
-### MatBlazor 0.6.13
+#### MatBlazor 0.6.13
 - New styles Layout Grid
 
-### MatBlazor 0.6.12
+#### MatBlazor 0.6.12
 - New component MatDialog
 - MatCheckbox add inline label (enkodellc)
 
-### MatBlazor 0.6.11
+#### MatBlazor 0.6.11
 - New component MatProgressBar
 
-### MatBlazor 0.6.10
+#### MatBlazor 0.6.10
 - New styles Elevation
 - License of used packages added to js boundle
 
-### MatBlazor 0.6.9
+#### MatBlazor 0.6.9
 - Changed all events to EventCallback
 - Show Icons when MatTextField has FullWidth (enkodellc)
 
-### MatBlazor 0.6.8
+#### MatBlazor 0.6.8
 - Improved events for MatTextField (sandrohanea + SamProf)
 
-### MatBlazor 0.6.7
+#### MatBlazor 0.6.7
 - Added Typography styles
 
-### MatBlazor 0.6.6
+#### MatBlazor 0.6.6
 - Added Href parameter to MatListItem component
 
-### MatBlazor 0.6.5
+#### MatBlazor 0.6.5
 - MatTextField - fixed label
 
-### MatBlazor 0.6.4
+#### MatBlazor 0.6.4
 - MatMenu - first working implementation
 
-### MatBlazor 0.6.3
+#### MatBlazor 0.6.3
 - New MatDrawer
 - Fix MatAppBar (fixed-adjust div)
 
-### MatBlazor 0.6.2
+#### MatBlazor 0.6.2
 - Added Style Parameter for all components
 - Added BaseMatComponent Docs
 - MatDrawer in progress
 
-### MatBlazor 0.6.1
+#### MatBlazor 0.6.1
 - Introduce Razor Components support (MatBlazorInstall component)
 
-### MatBlazor 0.6.0
+#### MatBlazor 0.6.0
 - Upgrade Blazor 0.9 complete
 - Upgrade to new Material Components
 - MatTextField Outlined fixed
@@ -541,17 +541,17 @@ Also we have official [Contributors team](https://github.com/SamProf/MatBlazor/i
 - MatDrawer (prepared for development in next release)
 - BlazorFiddle integration fixed
 
-### MatBlazor 0.5.0
+#### MatBlazor 0.5.0
 - Upgrade to Blazor 0.9.0 (Part 1)
 
-### MatBlazor 0.4.5 (Minor)
+#### MatBlazor 0.4.5 (Minor)
 - TrailingIcon in MatButton
 
-### MatBlazor 0.4.4
+#### MatBlazor 0.4.4
 - Added integration with BlazorFiddle.com
 - MatIconButton - Href bacame Link
 
-### MatBlazor 0.4.3
+#### MatBlazor 0.4.3
 - Upgrade to Blazor 0.7.0
 - MatDrawer in progress
 

--- a/src/MatBlazor.Demo.ClientApp/App.razor
+++ b/src/MatBlazor.Demo.ClientApp/App.razor
@@ -18,6 +18,9 @@
 
     MatTheme theme = new MatTheme()
     {
+        Primary = "#5d2f91",
+        Background = "#fafafa",
+        Surface = "#ffffff"
     };
 
 }

--- a/src/MatBlazor.Demo.ServerApp/App.razor
+++ b/src/MatBlazor.Demo.ServerApp/App.razor
@@ -24,6 +24,9 @@
 
     MatTheme theme = new MatTheme()
     {
+        Primary = "#5d2f91",
+        Background = "#fafafa",
+        Surface = "#ffffff"
     };
 
     private string _test1;

--- a/src/MatBlazor.Demo/Demo/DemoLayoutGrid.razor
+++ b/src/MatBlazor.Demo/Demo/DemoLayoutGrid.razor
@@ -7,7 +7,7 @@
     CSS Classes
 </h5>
 
-<table class="article-table mat-elevation-z5">
+<table class="article-table mat-elevation-z5 mdc-theme--surface">
     <tr>
         <th>CSS Class</th>
         <th>Description</th>

--- a/src/MatBlazor.Demo/Demo/DemoMatIcon.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatIcon.razor
@@ -51,7 +51,7 @@
 {
     <div class="mat-elevation-z5 demo-mat-icon-cat">
         <h4 class="mat-h6">@cat.Name</h4>
-        <div class="demo-mat-icon-icon-container">
+        <div class="demo-mat-icon-icon-container mdc-theme--surface">
 
             @foreach (var icon in cat.Icons)
             {

--- a/src/MatBlazor.Demo/Demo/DemoThemes.razor
+++ b/src/MatBlazor.Demo/Demo/DemoThemes.razor
@@ -183,23 +183,17 @@
     </SourceContent>
 </DemoContainer>
 
-
 <h5 class="mat-h5">Real use</h5>
-<p>To apply theme for all application you can use MatThemeProvider in MainLayout.razor or App.razor</p>
-<BlazorFiddle Template="MatBlazor" Code=@(@"
-    <MatThemeProvider Theme=""@theme"">
-        <Router AppAssembly=typeof(Pages.Index).Assembly/>
-    </MatThemeProvider>
-
-    @code
-    {
-        MatTheme theme = new MatTheme()
-        {
-            Primary = MatThemeColors.Orange._500.Value,
-            Secondary = MatThemeColors.BlueGrey._500.Value
-        };
-    }")>
-</BlazorFiddle>
+<DemoContainer> 
+    <Content>
+        <p>To apply theme for all application you can use MatThemeProvider in MainLayout.razor or App.razor</p>
+    </Content> 
+    <SourceContent> 
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <p>To apply theme for all application you can use MatThemeProvider in MainLayout.razor or App.razor</p>
+    ")></BlazorFiddle> 
+    </SourceContent>
+</DemoContainer>
 
 
 @code

--- a/src/MatBlazor.Demo/DemoContainer/DemoContainer.razor
+++ b/src/MatBlazor.Demo/DemoContainer/DemoContainer.razor
@@ -7,7 +7,7 @@
     <MatH5>@Header</MatH5>
 }
 
-<div style="display: flex; flex-direction: column; padding: 10px;" class="mat-elevation-z5">
+<div style="display: flex; flex-direction: column; padding: 10px;" class="mat-elevation-z5 mdc-theme--surface">
     <div style="padding: 5px; border: 1px solid white;" class="@Class">
         @Content
     </div>

--- a/src/MatBlazor.Demo/Doc/DocBindValueEvent.razor
+++ b/src/MatBlazor.Demo/Doc/DocBindValueEvent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">BindValueEvent</h3> } else { <h5 class="mat-h5">BindValueEvent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilder.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilder.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilder</h3> } else { <h5 class="mat-h5">ClassBuilder</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilderRule.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilderRule.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilderRule</h3> } else { <h5 class="mat-h5">ClassBuilderRule</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilderRuleClass.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilderRuleClass.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilderRuleClass</h3> } else { <h5 class="mat-h5">ClassBuilderRuleClass</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilderRuleDictionary.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilderRuleDictionary.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilderRuleDictionary</h3> } else { <h5 class="mat-h5">ClassBuilderRuleDictionary</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilderRuleGet.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilderRuleGet.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilderRuleGet</h3> } else { <h5 class="mat-h5">ClassBuilderRuleGet</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassBuilderRuleIf.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassBuilderRuleIf.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassBuilderRuleIf</h3> } else { <h5 class="mat-h5">ClassBuilderRuleIf</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocClassMapper.razor
+++ b/src/MatBlazor.Demo/Doc/DocClassMapper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ClassMapper</h3> } else { <h5 class="mat-h5">ClassMapper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocComponentBaseExtensions.razor
+++ b/src/MatBlazor.Demo/Doc/DocComponentBaseExtensions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ComponentBaseExtensions</h3> } else { <h5 class="mat-h5">ComponentBaseExtensions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocCoreMatOption.razor
+++ b/src/MatBlazor.Demo/Doc/DocCoreMatOption.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">CoreMatOption</h3> } else { <h5 class="mat-h5">CoreMatOption</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocCoreMatSelect.razor
+++ b/src/MatBlazor.Demo/Doc/DocCoreMatSelect.razor
@@ -8,7 +8,7 @@
 
 <p>Selects allow users to select from a single-option menu. It functions as a wrapper around the browser&#39;s native select element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocCoreMatSelectValue.razor
+++ b/src/MatBlazor.Demo/Doc/DocCoreMatSelectValue.razor
@@ -8,7 +8,7 @@
 
 <p>Selects allow users to select from a single-option menu. It functions as a wrapper around the browser&#39;s native select element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocExpandedStateChangedArgs.razor
+++ b/src/MatBlazor.Demo/Doc/DocExpandedStateChangedArgs.razor
@@ -8,7 +8,7 @@
 
 <p>Event arguments passed when a node expanded state changes</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocForwardRef.razor
+++ b/src/MatBlazor.Demo/Doc/DocForwardRef.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">ForwardRef</h3> } else { <h5 class="mat-h5">ForwardRef</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocGetChildNodesDelegate.razor
+++ b/src/MatBlazor.Demo/Doc/DocGetChildNodesDelegate.razor
@@ -8,7 +8,7 @@
 
 <p>A Callback used to get the child nodes for a given node</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIBaseCoreMatSelect.razor
+++ b/src/MatBlazor.Demo/Doc/DocIBaseCoreMatSelect.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IBaseCoreMatSelect</h3> } else { <h5 class="mat-h5">IBaseCoreMatSelect</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIBaseMatComponent.razor
+++ b/src/MatBlazor.Demo/Doc/DocIBaseMatComponent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IBaseMatComponent</h3> } else { <h5 class="mat-h5">IBaseMatComponent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIBaseMatPaginator.razor
+++ b/src/MatBlazor.Demo/Doc/DocIBaseMatPaginator.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IBaseMatPaginator</h3> } else { <h5 class="mat-h5">IBaseMatPaginator</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIMatFileUploadEntry.razor
+++ b/src/MatBlazor.Demo/Doc/DocIMatFileUploadEntry.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IMatFileUploadEntry</h3> } else { <h5 class="mat-h5">IMatFileUploadEntry</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIMatNavSubMenuToggler.razor
+++ b/src/MatBlazor.Demo/Doc/DocIMatNavSubMenuToggler.razor
@@ -8,7 +8,7 @@
 
 <p>Defines interface for a container component that<br/>can toggle the expansion state of its sub menus.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIMatToaster.razor
+++ b/src/MatBlazor.Demo/Doc/DocIMatToaster.razor
@@ -8,7 +8,7 @@
 
 <p>Represents an instance of the MatToaster engine</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIMatVirtualScroll.razor
+++ b/src/MatBlazor.Demo/Doc/DocIMatVirtualScroll.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IMatVirtualScroll</h3> } else { <h5 class="mat-h5">IMatVirtualScroll</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIMatVirtualScrollHelperTarget.razor
+++ b/src/MatBlazor.Demo/Doc/DocIMatVirtualScrollHelperTarget.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IMatVirtualScrollHelperTarget</h3> } else { <h5 class="mat-h5">IMatVirtualScrollHelperTarget</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIdGeneratorHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocIdGeneratorHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">IdGeneratorHelper</h3> } else { <h5 class="mat-h5">IdGeneratorHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocIsNodeExpandedDelegate.razor
+++ b/src/MatBlazor.Demo/Doc/DocIsNodeExpandedDelegate.razor
@@ -8,7 +8,7 @@
 
 <p>A Callback used to determine if a node should be expanded or collapsed</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocLinqExtensions.razor
+++ b/src/MatBlazor.Demo/Doc/DocLinqExtensions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">LinqExtensions</h3> } else { <h5 class="mat-h5">LinqExtensions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocLoadChildNodesDelegate.razor
+++ b/src/MatBlazor.Demo/Doc/DocLoadChildNodesDelegate.razor
@@ -8,7 +8,7 @@
 
 <p>Callback used to Lazy Load child nodes</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAccordion.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAccordion.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAccordion</h3> } else { <h5 class="mat-h5">MatAccordion</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAnchorContainer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAnchorContainer.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAnchorContainer</h3> } else { <h5 class="mat-h5">MatAnchorContainer</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAnchorLink.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAnchorLink.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAnchorLink</h3> } else { <h5 class="mat-h5">MatAnchorLink</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAnchorUtils.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAnchorUtils.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAnchorUtils</h3> } else { <h5 class="mat-h5">MatAnchorUtils</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBar.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBar.razor
@@ -8,7 +8,7 @@
 
 <p>Acts as a container for items such as application title, navigation icon, and action items.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarAction.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarAction.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarAction</h3> } else { <h5 class="mat-h5">MatAppBarAction</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarAdjust.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarAdjust.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarAdjust</h3> } else { <h5 class="mat-h5">MatAppBarAdjust</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarContainer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarContainer.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarContainer</h3> } else { <h5 class="mat-h5">MatAppBarContainer</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarContent</h3> } else { <h5 class="mat-h5">MatAppBarContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarNavigationIcon.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarNavigationIcon.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarNavigationIcon</h3> } else { <h5 class="mat-h5">MatAppBarNavigationIcon</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarRow.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarRow.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarRow</h3> } else { <h5 class="mat-h5">MatAppBarRow</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarSection.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarSection.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarSection</h3> } else { <h5 class="mat-h5">MatAppBarSection</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarSectionAlign.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarSectionAlign.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarSectionAlign</h3> } else { <h5 class="mat-h5">MatAppBarSectionAlign</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAppBarTitle.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAppBarTitle.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAppBarTitle</h3> } else { <h5 class="mat-h5">MatAppBarTitle</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAutocomplete.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAutocomplete.razor
@@ -8,7 +8,7 @@
 
 <p>Base class for any input control that optionally supports an .</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAutocompleteItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAutocompleteItem.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAutocompleteItem</h3> } else { <h5 class="mat-h5">MatAutocompleteItem</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAutocompleteList.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAutocompleteList.razor
@@ -8,7 +8,7 @@
 
 <p>The autocomplete is a normal text input enhanced by a panel of suggested options.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatAutocompleteListItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatAutocompleteListItem.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatAutocompleteListItem</h3> } else { <h5 class="mat-h5">MatAutocompleteListItem</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchT.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchT.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchT</h3> } else { <h5 class="mat-h5">MatBlazorSwitchT</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTBool.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTBool.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTBool</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTBool</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTBoolNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTBoolNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTBoolNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTBoolNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTByte.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTByte.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTByte</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTByte</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTByteNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTByteNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTByteNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTByteNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTChar.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTChar.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTChar</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTChar</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTCharNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTCharNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTCharNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTCharNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTCommon.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTCommon.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTCommon</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTCommon</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDateTime.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDateTime.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDateTime</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDateTime</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDateTimeNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDateTimeNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDateTimeNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDateTimeNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDecimal.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDecimal.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDecimal</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDecimal</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDecimalNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDecimalNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDecimalNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDecimalNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDouble.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDouble.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDouble</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDouble</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDoubleNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTDoubleNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTDoubleNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTDoubleNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTFloat.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTFloat.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTFloat</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTFloat</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTFloatNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTFloatNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTFloatNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTFloatNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTInt.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTInt.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTInt</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTInt</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTIntNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTIntNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTIntNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTIntNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTLong.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTLong.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTLong</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTLong</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTLongNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTLongNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTLongNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTLongNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTSByte.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTSByte.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTSByte</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTSByte</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTSByteNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTSByteNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTSByteNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTSByteNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTShort.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTShort.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTShort</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTShort</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTShortNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTShortNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTShortNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTShortNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTString.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTString.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTString</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTString</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUInt.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUInt.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTUInt</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTUInt</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUIntNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUIntNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTUIntNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTUIntNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTULong.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTULong.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTULong</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTULong</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTULongNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTULongNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTULongNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTULongNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUShort.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUShort.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTUShort</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTUShort</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUShortNull.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBlazorSwitchTUShortNull.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBlazorSwitchTUShortNull</h3> } else { <h5 class="mat-h5">MatBlazorSwitchTUShortNull</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBody1.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBody1.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBody1</h3> } else { <h5 class="mat-h5">MatBody1</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBody2.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBody2.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBody2</h3> } else { <h5 class="mat-h5">MatBody2</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatBreakpoint.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatBreakpoint.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatBreakpoint</h3> } else { <h5 class="mat-h5">MatBreakpoint</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatButton.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatButton.razor
@@ -8,7 +8,7 @@
 
 <p>Buttons communicate an action a user can take.<br/>They are typically placed throughout your UI, in places like dialogs, forms, cards, and toolbars.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCaption.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCaption.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCaption</h3> } else { <h5 class="mat-h5">MatCaption</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCard.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCard.razor
@@ -8,7 +8,7 @@
 
 <p>Card component for Blazor contain content and actions about a single subject.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCardActionButtons.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCardActionButtons.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCardActionButtons</h3> } else { <h5 class="mat-h5">MatCardActionButtons</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCardActionIcons.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCardActionIcons.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCardActionIcons</h3> } else { <h5 class="mat-h5">MatCardActionIcons</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCardActions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCardActions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCardActions</h3> } else { <h5 class="mat-h5">MatCardActions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCardContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCardContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCardContent</h3> } else { <h5 class="mat-h5">MatCardContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCardMedia.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCardMedia.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCardMedia</h3> } else { <h5 class="mat-h5">MatCardMedia</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCheckbox.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCheckbox.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design Checkboxes for Blazor, allow the user to select multiple options from a set.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatChip.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatChip.razor
@@ -8,7 +8,7 @@
 
 <p>Chips are compact elements that allow users to enter information, select a choice, filter content, or trigger an action.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatChipSet.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatChipSet.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatChipSet</h3> } else { <h5 class="mat-h5">MatChipSet</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatCombine.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatCombine.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatCombine</h3> } else { <h5 class="mat-h5">MatCombine</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatContentWrapper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatContentWrapper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatContentWrapper</h3> } else { <h5 class="mat-h5">MatContentWrapper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTable.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTable.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTable</h3> } else { <h5 class="mat-h5">MatDataTable</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableCell.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableCell.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableCell</h3> } else { <h5 class="mat-h5">MatDataTableCell</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableColumn.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableColumn.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableColumn</h3> } else { <h5 class="mat-h5">MatDataTableColumn</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableContent</h3> } else { <h5 class="mat-h5">MatDataTableContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableHeader.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableHeader</h3> } else { <h5 class="mat-h5">MatDataTableHeader</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableHeaderCell.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableHeaderCell.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableHeaderCell</h3> } else { <h5 class="mat-h5">MatDataTableHeaderCell</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDataTableRow.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDataTableRow.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDataTableRow</h3> } else { <h5 class="mat-h5">MatDataTableRow</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDatePicker.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDatePicker.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design Datetime picker for Blazor</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDatePickerJsHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDatePickerJsHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDatePickerJsHelper</h3> } else { <h5 class="mat-h5">MatDatePickerJsHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDatePickerPosition.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDatePickerPosition.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDatePickerPosition</h3> } else { <h5 class="mat-h5">MatDatePickerPosition</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDialog.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDialog.razor
@@ -8,7 +8,7 @@
 
 <p>Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDialogActions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDialogActions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDialogActions</h3> } else { <h5 class="mat-h5">MatDialogActions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDialogContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDialogContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDialogContent</h3> } else { <h5 class="mat-h5">MatDialogContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDialogTitle.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDialogTitle.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDialogTitle</h3> } else { <h5 class="mat-h5">MatDialogTitle</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDivider.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDivider.razor
@@ -8,7 +8,7 @@
 
 <p>MatDivider is a component that allows for Material styling of a line separator with various orientation options.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDotNetObjectReference.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDotNetObjectReference.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDotNetObjectReference</h3> } else { <h5 class="mat-h5">MatDotNetObjectReference</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDrawer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDrawer.razor
@@ -8,7 +8,7 @@
 
 <p>The navigation drawer slides in from the left and contains the navigation destinations for your app.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDrawerContainer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDrawerContainer.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDrawerContainer</h3> } else { <h5 class="mat-h5">MatDrawerContainer</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDrawerContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDrawerContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDrawerContent</h3> } else { <h5 class="mat-h5">MatDrawerContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatDrawerMode.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatDrawerMode.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatDrawerMode</h3> } else { <h5 class="mat-h5">MatDrawerMode</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatEventCallback.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatEventCallback.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatEventCallback</h3> } else { <h5 class="mat-h5">MatEventCallback</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanel.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanel.razor
@@ -8,7 +8,7 @@
 
 <p>MatExpansionPanel provides an expandable details-summary view.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanelDetails.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanelDetails.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatExpansionPanelDetails</h3> } else { <h5 class="mat-h5">MatExpansionPanelDetails</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanelHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanelHeader.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatExpansionPanelHeader</h3> } else { <h5 class="mat-h5">MatExpansionPanelHeader</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanelSubHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanelSubHeader.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatExpansionPanelSubHeader</h3> } else { <h5 class="mat-h5">MatExpansionPanelSubHeader</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatExpansionPanelSummary.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatExpansionPanelSummary.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatExpansionPanelSummary</h3> } else { <h5 class="mat-h5">MatExpansionPanelSummary</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatFAB.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatFAB.razor
@@ -8,7 +8,7 @@
 
 <p>A floating action button represents the primary action in an application.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatFileUpload.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatFileUpload.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatFileUpload</h3> } else { <h5 class="mat-h5">MatFileUpload</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatFileUploadEntry.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatFileUploadEntry.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatFileUploadEntry</h3> } else { <h5 class="mat-h5">MatFileUploadEntry</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH1.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH1.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH1</h3> } else { <h5 class="mat-h5">MatH1</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH2.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH2.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH2</h3> } else { <h5 class="mat-h5">MatH2</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH3.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH3.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH3</h3> } else { <h5 class="mat-h5">MatH3</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH4.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH4.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH4</h3> } else { <h5 class="mat-h5">MatH4</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH5.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH5.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH5</h3> } else { <h5 class="mat-h5">MatH5</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatH6.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatH6.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatH6</h3> } else { <h5 class="mat-h5">MatH6</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline1.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline1.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline1</h3> } else { <h5 class="mat-h5">MatHeadline1</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline2.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline2.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline2</h3> } else { <h5 class="mat-h5">MatHeadline2</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline3.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline3.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline3</h3> } else { <h5 class="mat-h5">MatHeadline3</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline4.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline4.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline4</h3> } else { <h5 class="mat-h5">MatHeadline4</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline5.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline5.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline5</h3> } else { <h5 class="mat-h5">MatHeadline5</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHeadline6.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHeadline6.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHeadline6</h3> } else { <h5 class="mat-h5">MatHeadline6</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHelperText.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHelperText.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHelperText</h3> } else { <h5 class="mat-h5">MatHelperText</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHidden.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHidden.razor
@@ -8,7 +8,7 @@
 
 <p>Quickly and responsively toggle the visibility value of components and more with our hidden utilities.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHiddenDirection.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHiddenDirection.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHiddenDirection</h3> } else { <h5 class="mat-h5">MatHiddenDirection</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHiddenUtils.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHiddenUtils.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHiddenUtils</h3> } else { <h5 class="mat-h5">MatHiddenUtils</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatHttpClientExtension.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatHttpClientExtension.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatHttpClientExtension</h3> } else { <h5 class="mat-h5">MatHttpClientExtension</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIcon.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIcon.razor
@@ -8,7 +8,7 @@
 
 <p>Makes it easier to use vector-based icons in your app.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIconButton.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconButton.razor
@@ -8,7 +8,7 @@
 
 <p>Icons are appropriate for buttons that allow a user to take actions or make a selection, such as adding or removing a star to an item.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIconCategories.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconCategories.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatIconCategories</h3> } else { <h5 class="mat-h5">MatIconCategories</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIconDataCategory.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconDataCategory.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatIconDataCategory</h3> } else { <h5 class="mat-h5">MatIconDataCategory</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIconDataIcon.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconDataIcon.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatIconDataIcon</h3> } else { <h5 class="mat-h5">MatIconDataIcon</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatIconNames.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatIconNames.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatIconNames</h3> } else { <h5 class="mat-h5">MatIconNames</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatInputTextComponent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatInputTextComponent.razor
@@ -8,7 +8,7 @@
 
 <p>Base class for any input control that optionally supports an .</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatItemsControl.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatItemsControl.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatItemsControl</h3> } else { <h5 class="mat-h5">MatItemsControl</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatList.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatList.razor
@@ -8,7 +8,7 @@
 
 <p>Lists present multiple line items vertically as a single continuous element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListDivider.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListDivider.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListDivider</h3> } else { <h5 class="mat-h5">MatListDivider</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListGroup.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListGroup.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListGroup</h3> } else { <h5 class="mat-h5">MatListGroup</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListGroupSubHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListGroupSubHeader.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListGroupSubHeader</h3> } else { <h5 class="mat-h5">MatListGroupSubHeader</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListItem.razor
@@ -8,7 +8,7 @@
 
 <p>Lists present multiple line items vertically as a single continuous element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListItemPrimaryText.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListItemPrimaryText.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListItemPrimaryText</h3> } else { <h5 class="mat-h5">MatListItemPrimaryText</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListItemSecondaryText.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListItemSecondaryText.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListItemSecondaryText</h3> } else { <h5 class="mat-h5">MatListItemSecondaryText</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListItemText.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListItemText.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListItemText</h3> } else { <h5 class="mat-h5">MatListItemText</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatListJsOptions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatListJsOptions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatListJsOptions</h3> } else { <h5 class="mat-h5">MatListJsOptions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatMenu.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatMenu.razor
@@ -8,7 +8,7 @@
 
 <p>Menus display a list of choices on a transient sheet of material.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNavItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNavItem.razor
@@ -8,7 +8,7 @@
 
 <p>Nav Item is a menu item in the Nav Menu. Inherits from Mat List Item.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNavMenu.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNavMenu.razor
@@ -8,7 +8,7 @@
 
 <p>MatNavMenu provides a navigation container</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNavSubMenu.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNavSubMenu.razor
@@ -8,7 +8,7 @@
 
 <p>MatNavSubMenu provides an expandable panel for child navigation lists.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNavSubMenuHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNavSubMenuHeader.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatNavSubMenuHeader</h3> } else { <h5 class="mat-h5">MatNavSubMenuHeader</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNavSubMenuList.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNavSubMenuList.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatNavSubMenuList</h3> } else { <h5 class="mat-h5">MatNavSubMenuList</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNumericUpDownField.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNumericUpDownField.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design NumericUpDown for Blazor, text fields allow users to input, edit, and select text.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatNumericUpDownFieldType.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatNumericUpDownFieldType.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatNumericUpDownFieldType</h3> } else { <h5 class="mat-h5">MatNumericUpDownFieldType</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatOption.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatOption.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatOption</h3> } else { <h5 class="mat-h5">MatOption</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatOptionString.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatOptionString.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatOptionString</h3> } else { <h5 class="mat-h5">MatOptionString</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatOverline.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatOverline.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatOverline</h3> } else { <h5 class="mat-h5">MatOverline</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatPageSizeOption.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatPageSizeOption.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatPageSizeOption</h3> } else { <h5 class="mat-h5">MatPageSizeOption</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatPaginator.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatPaginator.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatPaginator</h3> } else { <h5 class="mat-h5">MatPaginator</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatPaginatorAction.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatPaginatorAction.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatPaginatorAction</h3> } else { <h5 class="mat-h5">MatPaginatorAction</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatPaginatorPageEvent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatPaginatorPageEvent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatPaginatorPageEvent</h3> } else { <h5 class="mat-h5">MatPaginatorPageEvent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatProgressBar.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatProgressBar.razor
@@ -8,7 +8,7 @@
 
 <p>Progress indicators display the length of a process or express an unspecified wait time.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatRadioButton.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatRadioButton.razor
@@ -8,7 +8,7 @@
 
 <p>Buttons communicate an action a user can take. They are typically placed throughout your UI, in places like dialogs, forms, cards, and toolbars.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatRadioGroup.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatRadioGroup.razor
@@ -8,7 +8,7 @@
 
 <p></p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatRipple.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatRipple.razor
@@ -8,7 +8,7 @@
 
 <p>Ripples are visual representations used to communicate the status of a component or interactive element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatRippleColor.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatRippleColor.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatRippleColor</h3> } else { <h5 class="mat-h5">MatRippleColor</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSelect.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSelect.razor
@@ -8,7 +8,7 @@
 
 <p>Selects allow users to select from a single-option menu. It functions as a wrapper around the browser&#39;s native select element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSelectItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSelectItem.razor
@@ -8,7 +8,7 @@
 
 <p>Selects allow users to select from a single-option menu. It functions as a wrapper around the browser&#39;s native select element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSelectJsHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSelectJsHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSelectJsHelper</h3> } else { <h5 class="mat-h5">MatSelectJsHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSelectValue.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSelectValue.razor
@@ -8,7 +8,7 @@
 
 <p>Selects allow users to select from a single-option menu. It functions as a wrapper around the browser&#39;s native select element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSlideToggle.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSlideToggle.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design SlideToggle for Blazor. Component for on/off control that can be toggled via clicking or dragging.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSlider.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSlider.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design Slider for Blazor. Sliders let users select from a range of values by moving the slider thumb.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSliderJsHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSliderJsHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSliderJsHelper</h3> } else { <h5 class="mat-h5">MatSliderJsHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSnackbar.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSnackbar.razor
@@ -8,7 +8,7 @@
 
 <p>Snackbars provide brief messages about app processes at the bottom of the screen.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSnackbarActions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSnackbarActions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSnackbarActions</h3> } else { <h5 class="mat-h5">MatSnackbarActions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSnackbarContent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSnackbarContent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSnackbarContent</h3> } else { <h5 class="mat-h5">MatSnackbarContent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSortChangedEvent.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSortChangedEvent.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSortChangedEvent</h3> } else { <h5 class="mat-h5">MatSortChangedEvent</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSortDirection.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSortDirection.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSortDirection</h3> } else { <h5 class="mat-h5">MatSortDirection</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSortHeader.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSortHeader.razor
@@ -8,7 +8,7 @@
 
 <p>The MatSortHeader and MatSortHeaderRow are used, respectively, to add sorting state and display to tabular data.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSortHeaderRow.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSortHeaderRow.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSortHeaderRow</h3> } else { <h5 class="mat-h5">MatSortHeaderRow</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatStringField.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatStringField.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design Text Field for Blazor. Text fields allow users to input, edit, and select text.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSubtitle1.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSubtitle1.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSubtitle1</h3> } else { <h5 class="mat-h5">MatSubtitle1</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSubtitle2.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSubtitle2.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSubtitle2</h3> } else { <h5 class="mat-h5">MatSubtitle2</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatSwitchT.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatSwitchT.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatSwitchT</h3> } else { <h5 class="mat-h5">MatSwitchT</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTab.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTab.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTab</h3> } else { <h5 class="mat-h5">MatTab</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTabBar.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTabBar.razor
@@ -8,7 +8,7 @@
 
 <p>WARNING: In Development progress</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTabGroup.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTabGroup.razor
@@ -8,7 +8,7 @@
 
 <p>MatTabGroup organize content into separate views where only one view can be visible at a time. Each tab&#39;s label is shown in the tab header and the active tab&#39;s label is designated with the animated ink bar.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTabLabel.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTabLabel.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTabLabel</h3> } else { <h5 class="mat-h5">MatTabLabel</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTable.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTable.razor
@@ -8,7 +8,7 @@
 
 <p>Mat Table display a table data.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTextField.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTextField.razor
@@ -8,7 +8,7 @@
 
 <p>Material Design Text Field for Blazor. Text fields allow users to input, edit, and select text.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTheme.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTheme.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTheme</h3> } else { <h5 class="mat-h5">MatTheme</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColor.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColor.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColor</h3> } else { <h5 class="mat-h5">MatThemeColor</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorAmber.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorAmber.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorAmber</h3> } else { <h5 class="mat-h5">MatThemeColorAmber</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorBlue.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorBlue.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorBlue</h3> } else { <h5 class="mat-h5">MatThemeColorBlue</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorBlueGrey.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorBlueGrey.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorBlueGrey</h3> } else { <h5 class="mat-h5">MatThemeColorBlueGrey</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorBrown.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorBrown.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorBrown</h3> } else { <h5 class="mat-h5">MatThemeColorBrown</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorCyan.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorCyan.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorCyan</h3> } else { <h5 class="mat-h5">MatThemeColorCyan</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorDeepOrange.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorDeepOrange.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorDeepOrange</h3> } else { <h5 class="mat-h5">MatThemeColorDeepOrange</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorDeepPurple.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorDeepPurple.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorDeepPurple</h3> } else { <h5 class="mat-h5">MatThemeColorDeepPurple</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorGreen.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorGreen.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorGreen</h3> } else { <h5 class="mat-h5">MatThemeColorGreen</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorGrey.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorGrey.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorGrey</h3> } else { <h5 class="mat-h5">MatThemeColorGrey</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorIndigo.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorIndigo.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorIndigo</h3> } else { <h5 class="mat-h5">MatThemeColorIndigo</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorLightBlue.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorLightBlue.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorLightBlue</h3> } else { <h5 class="mat-h5">MatThemeColorLightBlue</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorLightGreen.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorLightGreen.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorLightGreen</h3> } else { <h5 class="mat-h5">MatThemeColorLightGreen</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorLime.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorLime.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorLime</h3> } else { <h5 class="mat-h5">MatThemeColorLime</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorOrange.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorOrange.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorOrange</h3> } else { <h5 class="mat-h5">MatThemeColorOrange</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorPink.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorPink.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorPink</h3> } else { <h5 class="mat-h5">MatThemeColorPink</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorPurple.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorPurple.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorPurple</h3> } else { <h5 class="mat-h5">MatThemeColorPurple</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorRed.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorRed.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorRed</h3> } else { <h5 class="mat-h5">MatThemeColorRed</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorShadow.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorShadow.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorShadow</h3> } else { <h5 class="mat-h5">MatThemeColorShadow</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorTeal.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorTeal.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorTeal</h3> } else { <h5 class="mat-h5">MatThemeColorTeal</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColorYellow.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColorYellow.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColorYellow</h3> } else { <h5 class="mat-h5">MatThemeColorYellow</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeColors.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeColors.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatThemeColors</h3> } else { <h5 class="mat-h5">MatThemeColors</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatThemeProvider.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatThemeProvider.razor
@@ -8,7 +8,7 @@
 
 <p>The Material Design color system can be used to create a color theme that reflects your brand or style.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToast.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToast.razor
@@ -8,7 +8,7 @@
 
 <p>Represents an instance of a Toast<br/>It handles the user interactions and orchestrates the state transitions</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastClasses.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastClasses.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastClasses</h3> } else { <h5 class="mat-h5">MatToastClasses</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastCommonOptions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastCommonOptions.razor
@@ -8,7 +8,7 @@
 
 <p>The common options for MatToaster</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastConfiguration.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastConfiguration.razor
@@ -8,7 +8,7 @@
 
 <p>Represents the global  instance</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastContainer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastContainer.razor
@@ -8,7 +8,7 @@
 
 <p>Toasts provide brief notifications or messages about app processes</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastExtension.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastExtension.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastExtension</h3> } else { <h5 class="mat-h5">MatToastExtension</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastItem.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastItem.razor
@@ -8,7 +8,7 @@
 
 <p>Toasts provide brief notifications or messages about app processes</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastOptions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastOptions.razor
@@ -8,7 +8,7 @@
 
 <p>The common options for MatToaster</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastPosition.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastPosition.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastPosition</h3> } else { <h5 class="mat-h5">MatToastPosition</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastState.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastState.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastState</h3> } else { <h5 class="mat-h5">MatToastState</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastTransitionState.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastTransitionState.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastTransitionState</h3> } else { <h5 class="mat-h5">MatToastTransitionState</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastTransitionTimer.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastTransitionTimer.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastTransitionTimer</h3> } else { <h5 class="mat-h5">MatToastTransitionTimer</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToastType.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToastType.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToastType</h3> } else { <h5 class="mat-h5">MatToastType</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToaster.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToaster.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToaster</h3> } else { <h5 class="mat-h5">MatToaster</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatToatsPositionConvertor.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatToatsPositionConvertor.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatToatsPositionConvertor</h3> } else { <h5 class="mat-h5">MatToatsPositionConvertor</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTooltip.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTooltip.razor
@@ -8,7 +8,7 @@
 
 <p>The Material tooltip provides a text label that is displayed when the user hovers an element.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTooltipJSOptions.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTooltipJSOptions.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTooltipJSOptions</h3> } else { <h5 class="mat-h5">MatTooltipJSOptions</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTooltipPosition.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTooltipPosition.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTooltipPosition</h3> } else { <h5 class="mat-h5">MatTooltipPosition</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTreeNode.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTreeNode.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTreeNode</h3> } else { <h5 class="mat-h5">MatTreeNode</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTreeView.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTreeView.razor
@@ -8,7 +8,7 @@
 
 <p>Renders the data as a tree.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatTypeConverter.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatTypeConverter.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatTypeConverter</h3> } else { <h5 class="mat-h5">MatTypeConverter</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatViewChildren.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatViewChildren.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatViewChildren</h3> } else { <h5 class="mat-h5">MatViewChildren</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatVirtualScroll.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatVirtualScroll.razor
@@ -8,7 +8,7 @@
 
 <p>The VirtualScroll for Blazor displays large lists of elements performantly by only rendering the items that fit on-screen.<br/>Loading hundreds of elements can be slow in any browser; virtual scrolling enables a performant way to simulate all items being rendered by making the height of the container element the same as the height of total number of elements to be rendered, and then only rendering the items in view.</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatVirtualScrollHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatVirtualScrollHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatVirtualScrollHelper</h3> } else { <h5 class="mat-h5">MatVirtualScrollHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatVirtualScrollJsHelper.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatVirtualScrollJsHelper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatVirtualScrollJsHelper</h3> } else { <h5 class="mat-h5">MatVirtualScrollJsHelper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatVirtualScrollView.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatVirtualScrollView.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatVirtualScrollView</h3> } else { <h5 class="mat-h5">MatVirtualScrollView</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocMatVirtualScrollViewResult.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatVirtualScrollViewResult.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">MatVirtualScrollViewResult</h3> } else { <h5 class="mat-h5">MatVirtualScrollViewResult</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocPageDirection.razor
+++ b/src/MatBlazor.Demo/Doc/DocPageDirection.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">PageDirection</h3> } else { <h5 class="mat-h5">PageDirection</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocPageSizeStructure.razor
+++ b/src/MatBlazor.Demo/Doc/DocPageSizeStructure.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">PageSizeStructure</h3> } else { <h5 class="mat-h5">PageSizeStructure</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocStyleMapper.razor
+++ b/src/MatBlazor.Demo/Doc/DocStyleMapper.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">StyleMapper</h3> } else { <h5 class="mat-h5">StyleMapper</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/DocTableRow.razor
+++ b/src/MatBlazor.Demo/Doc/DocTableRow.razor
@@ -8,7 +8,7 @@
 
 <p>Mat Table Row display a table row</p>
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Doc/Doc_Imports.razor
+++ b/src/MatBlazor.Demo/Doc/Doc_Imports.razor
@@ -6,7 +6,7 @@
 
 @if (!Secondary) {<h3 class="mat-h3">_Imports</h3> } else { <h5 class="mat-h5">_Imports</h5> }
 
-<div><table class="article-table mat-elevation-z5">
+<div><table class="article-table mat-elevation-z5 mdc-theme--surface">
 	<tr>
 		<th>Name</th>
 		<th>Type</th>

--- a/src/MatBlazor.Demo/Pages/Index.razor
+++ b/src/MatBlazor.Demo/Pages/Index.razor
@@ -3,44 +3,48 @@
 @using System.Diagnostics
 @implements IDisposable
 
-
-<h1 class="mat-h1"><img src="https://raw.githubusercontent.com/SamProf/MatBlazor/master/content/logo.png" style="max-height: 100px;"/> MatBlazor</h1>
-<h4 class="mat-h4">Material Design components for Blazor (@(GetVersion()))</h4>
-<div>
-    <a href="https://www.nuget.org/packages/MatBlazor/" target="_blank">
-        <img src="https://img.shields.io/nuget/v/MatBlazor.svg"/>
-    </a>
-    <a href="https://gitter.im/MatBlazor/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge" target="_blank">
-        <img src="https://badges.gitter.im/MatBlazor/community.svg"/>
-    </a>
-    <a href="https://github.com/SamProf/MatBlazor" target="_blank">
-        <img src="https://img.shields.io/github/stars/SamProf/MatBlazor.svg"/>
-    </a>
-    <a href="https://github.com/SamProf/MatBlazor/issues" target="_blank">
-        <img src="https://img.shields.io/github/issues/SamProf/matblazor.svg"/>
-    </a>
-    <a href="https://github.com/SamProf/MatBlazor/blob/master/LICENSE" target="_blank">
-        <img src="https://img.shields.io/github/license/SamProf/MatBlazor.svg"/>
-    </a>
-    <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9XT68N2VKWTPE&source=url" target="_blank" style="margin-left: 5px;">
-        <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif"/>
-    </a>
-</div>
-
-
 <style>
     .blazor-fiddle { overflow-wrap: break-word; }
 
-    .index-row-item { padding: 5px; }
+    .index-row-item { padding: 24px; }
+
 </style>
 
 
-<div class="mat-layout-grid index-row-container">
+<div class="mat-layout-grid">
     <div class="mat-layout-grid-inner">
 
-        <div class="mat-layout-grid-cell mat-layout-grid-cell-span-6 mat-elevation-z2 index-row-item">
+        <div class="mat-layout-grid-cell-span-12">
+            <h1 class="mat-h1"><img src="https://raw.githubusercontent.com/SamProf/MatBlazor/master/content/logo.png" style="max-height: 100px;" /> MatBlazor</h1>
+            <h4 class="mat-h4">Material Design components for Blazor (@(GetVersion()))</h4>
+            <div>
+                <a href="https://www.nuget.org/packages/MatBlazor/" target="_blank">
+                    <img src="https://img.shields.io/nuget/v/MatBlazor.svg" />
+                </a>
+                <a href="https://gitter.im/MatBlazor/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge" target="_blank">
+                    <img src="https://badges.gitter.im/MatBlazor/community.svg" />
+                </a>
+                <a href="https://github.com/SamProf/MatBlazor" target="_blank">
+                    <img src="https://img.shields.io/github/stars/SamProf/MatBlazor.svg" />
+                </a>
+                <a href="https://github.com/SamProf/MatBlazor/issues" target="_blank">
+                    <img src="https://img.shields.io/github/issues/SamProf/matblazor.svg" />
+                </a>
+                <a href="https://github.com/SamProf/MatBlazor/blob/master/LICENSE" target="_blank">
+                    <img src="https://img.shields.io/github/license/SamProf/MatBlazor.svg" />
+                </a>
+                <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9XT68N2VKWTPE&source=url" target="_blank" style="margin-left: 5px;">
+                    <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" />
+                </a>
+            </div>
+        </div>
+
+
+
+
+        <div class="mat-layout-grid-cell mat-layout-grid-cell-span-12 mat-elevation-z5 index-row-item mdc-theme--surface">
             <div class="">
-                <h5 class="mat-h5">Installation</h5>
+                <h2 class="mat-h2">Installation</h2>
 
                 <p>
                     Install MatBlazor library via nuget.
@@ -61,8 +65,8 @@
                 </p>
             </div>
 
-            <div class="">
-                <h5 class="mat-h5">_Imports.razor</h5>
+            <div>
+                <h4 class="mat-h4">_Imports.razor</h4>
                 <p>
                     Add @@using MatBlazor in main _Imports.razor
                 </p>
@@ -71,7 +75,7 @@
                     <BlazorFiddle Template="MatBlazor" Code=@(@"@using MatBlazor")>
                     </BlazorFiddle>
                 </p>
-                <h5 class="mat-h5">Usage</h5>
+                <h4 class="mat-h4">Usage</h4>
                 <p>
                     MatBlazor components are self-supporting.
                 </p>
@@ -81,7 +85,7 @@
                     </BlazorFiddle>
                 </p>
 
-                <h5 class="mat-h5">Static files</h5>
+                <h4 class="mat-h4">Static files</h4>
 
                 <p>
                     For client-side and server-side Blazor - add script section to index.html or _Host.cshtml (head section)
@@ -98,22 +102,10 @@
                 <Sponsors></Sponsors>
             </div>
 
-            <div>
-                <h5 class="mat-h5">Components: </h5>
-                <DemoDrawerContent></DemoDrawerContent>
-
-
-            </div>
-
-
         </div>
 
-        <div class="mat-layout-grid-cell mat-layout-grid-cell-span-6 mat-elevation-z2 index-row-item">
-            <div class="">
+        <div class="mat-layout-grid-cell mat-layout-grid-cell-span-12 mat-elevation-z5 index-row-item mdc-theme--surface">
                 <News></News>
-            </div>
-
-
         </div>
     </div>
 </div>

--- a/src/MatBlazor.Demo/Shared/MainLayout.razor
+++ b/src/MatBlazor.Demo/Shared/MainLayout.razor
@@ -50,9 +50,11 @@
     </MatHidden>
 
 
-    <MatDrawerContent Style="padding-left: 25px; padding-right: 25px;">
+    <MatDrawerContent Class="mdc-theme--background">
         <MatAppBarAdjust></MatAppBarAdjust>
-        @Body
+        <div class="body-wrapper">
+            @Body
+        </div>
     </MatDrawerContent>
 
 </MatDrawerContainer>

--- a/src/MatBlazor.Demo/Shared/News.razor
+++ b/src/MatBlazor.Demo/Shared/News.razor
@@ -1,7 +1,7 @@
 @* THIS IS AUTO GENERATED FILE!!! *@
 
-<h2>News</h2>
-<h3>Roadmap</h3>
+<h2 class="mat-h2">News</h2>
+<h3 class="mat-h3">Roadmap</h3>
 <ul>
 <li><code>MatVirtualScroll</code> - complete new component</li>
 <li><code>MatDataTable</code> - complete new component</li>
@@ -9,7 +9,7 @@
 <li><code>MatTreeView</code> - complete new component</li>
 <li><code>MatAutocomplete</code> - new implementation of component</li>
 </ul>
-<h4>MatBlazor 2.6.1 (Develop)</h4>
+<h4 class="mat-h4">MatBlazor 2.6.1 (Develop)</h4>
 <ul>
 <li>PR: MatChip / MatChipSet: implemented exclusive and non-exclusive selection #601 (Thanks to <a href="https://github.com/henon">henon</a>)</li>
 <li>PR: Bugfix for pagecounter in MatTable #561 (Thanks to <a href="https://github.com/lindespang">lindespang</a>)</li>
@@ -21,7 +21,7 @@
 <li>PR: Added ForceLoad option for MatButton and MatIconButton (Fixes #330) #570 (Thanks to <a href="https://github.com/Garderoben">Garderoben</a> and <a href="https://github.com/enkodellc">enkodellc</a>)</li>
 <li>PR: Added LazyRendering for MatExpansionPanel + bug fix #578 (Thanks to <a href="https://github.com/lindespang">lindespang</a>)</li>
 </ul>
-<h4>MatBlazor 2.6.0</h4>
+<h4 class="mat-h4">MatBlazor 2.6.0</h4>
 <ul>
 <li>Update to Latest Microsoft.AspNetCore.Components 3.1.4 and Microsoft.AspNetCore.Components.WebAssembly 3.2.0</li>
 <li>Update MDC-Web components to 6.0.0</li>
@@ -34,7 +34,7 @@
 <li>PR: Added Primary Color to MatSelect Label #522 (Thanks to <a href="https://github.com/EduVencovsky">EduVencovsky</a>)</li>
 <li>PR: Added documentation for SlideToggle value changed event. #530 (Thanks to <a href="https://github.com/SeppPenner">SeppPenner</a>)</li>
 </ul>
-<h4>MatBlazor 2.4.3</h4>
+<h4 class="mat-h4">MatBlazor 2.4.3</h4>
 <ul>
 <li><code>MatVirtualScroll</code> - New component-</li>
 <li>Added label color to theme primary color #488 (Thanks to <a href="https://github.com/EduVencovsky">EduVencovsky</a>)</li>
@@ -44,7 +44,7 @@
 <li>PR: Use height instead of max-height in mat-expansion-panel base/expanded #484 (Thanks to <a href="https://github.com/esso23">esso23</a>)</li>
 <li>PR: Remove node-sass and add temporary workaround for sass-loader. #481 (Thanks to <a href="https://github.com/esso23">esso23</a>)</li>
 </ul>
-<h4>MatBlazor 2.3.0</h4>
+<h4 class="mat-h4">MatBlazor 2.3.0</h4>
 <ul>
 <li>PR: Add implementations for nullable primitive types: <code>sbyte?</code>, <code>byte?</code>, <code>short?</code>, <code>ushort?</code>, <code>int?</code>, <code>uint?</code>, <code>long?</code>, <code>ulong?</code>, <code>char?</code>, <code>float?</code>, <code>double?</code> #449 (Thanks to <a href="https://github.com/fire-birdie">fire-birdie</a>)</li>
 <li>MatNumericUpDownField - Added FieldType parameter with Numeric, Currency, and Percent types #462 (Thanks to <a href="https://github.com/RonPeters">RonPeters</a>)</li>
@@ -59,26 +59,26 @@
 <li>PR: ToolTip Fix #450 (Thanks to <a href="https://github.com/EduVencovsky">EduVencovsky</a>)</li>
 <li>PR: package.json - Fixed invalid structure and updated some packages to address some of the vulnerabilities identified in audit #462 (Thanks to <a href="https://github.com/RonPeters">RonPeters</a>)</li>
 </ul>
-<h4>MatBlazor 2.2.0</h4>
+<h4 class="mat-h4">MatBlazor 2.2.0</h4>
 <ul>
 <li>.NET Core 3.1.2 + .NET Core 3.2.0-Preview 1 Releases</li>
 <li><code>MatSortHeader</code>, <code>MatSortHeaderRow</code> - New component</li>
 <li>Fix: MatDatePicker always display's current month/year #431</li>
 </ul>
-<h4>MatBlazor 2.1.2</h4>
+<h4 class="mat-h4">MatBlazor 2.1.2</h4>
 <ul>
 <li><code>MatPaginator</code> - New component</li>
 <li>Fix: Impelement custom <code>hoistMenuToBody</code> for MatSelect and MatMenu - fix #415</li>
 <li>Fix: Ripple effect for MatButton</li>
 </ul>
-<h4>MatBlazor 2.1.1</h4>
+<h4 class="mat-h4">MatBlazor 2.1.1</h4>
 <ul>
 <li>MatSelect, MatSelectItem, MatSelectValue components supports EditContext</li>
 <li>ValidationDisabled parameter added to input components</li>
 <li>PR: Update MatBlazor Demo Menu #414 (Thanks to <a href="https://github.com/americanslon">americanslon</a>)</li>
 <li>PR: Updated prerequisites #413 (Thanks to <a href="https://github.com/NPadrutt">NPadrutt</a>)</li>
 </ul>
-<h4>MatBlazor 2.1.0</h4>
+<h4 class="mat-h4">MatBlazor 2.1.0</h4>
 <ul>
 <li>
 <p>Breaking changes - Upgrade an existing project</p>
@@ -115,13 +115,13 @@
 <p><code>MatFileUpload</code> - progress bar added, improoved performance</p>
 </li>
 </ul>
-<h4>MatBlazor 2.0.5</h4>
+<h4 class="mat-h4">MatBlazor 2.0.5</h4>
 <ul>
 <li><code>MatFileUpload</code> - inital version of component</li>
 <li>Implemented: Add possibility of initial state of MatIconButton #401. Implemented <code>Toggled</code> parameter and <code>ToggledChanged</code>.</li>
 <li>Fixed: Small bug with numeric up/down field #402. Overflow in numeric values.</li>
 </ul>
-<h4>MatBlazor 2.0.1</h4>
+<h4 class="mat-h4">MatBlazor 2.0.1</h4>
 <ul>
 <li><code>MatSelect</code> was rewrited and prepared for <code>MatSelectItem</code> and <code>MatSelectValue</code>, supported only <code>Enhanced</code> mode, Disabled for <code>MatOption</code> is temporary not working</li>
 <li>PR: Added MatTreeView #360 (Thanks to <a href="https://github.com/sprotty">sprotty</a>)</li>
@@ -132,7 +132,7 @@
 <li>PR: added @@key attribute to MatTab content #395 (Thanks to <a href="https://github.com/chris1411">chris1411</a>)</li>
 <li>PR: Matlist selectedIndex default value set to -1 #354 (Thanks to <a href="https://github.com/radutomy">radutomy</a>)</li>
 </ul>
-<h3>MatBlazor 2.0.0 (Reinvention MatBlazor Forms)</h3>
+<h4 class="mat-h4">MatBlazor 2.0.0 (Reinvention MatBlazor Forms)</h4>
 <ul>
 <li>This release contain a lot of breaking changes, sorry for that.</li>
 <li>The main goal of this release was to unify all components for forms, generic type support, reduction of dependence of JS, active use of OOP and the possibility of more active expansion in the future.</li>
@@ -215,7 +215,7 @@
 </li>
 <li><code>MatBlazorInstall</code> - removed</li>
 </ul>
-<h3>MatBlazor 1.10.1</h3>
+<h4 class="mat-h4">MatBlazor 1.10.1</h4>
 <ul>
 <li>Update to .NET Core 3.1 Preview 1</li>
 <li>Added an active index to the MatTabGroup and MatTabBar #289 (Thanks to <a href="https://github.com/chris1411">chris1411</a>)</li>
@@ -224,50 +224,50 @@
 <li>Update Readme.md (EmbeddedBlazorContent) #270 (Thanks to <a href="https://github.com/manuel3108">manuel3108</a>)</li>
 <li>Update BlazorBoilerplate description #299 (Thanks to <a href="https://github.com/enkodellc">enkodellc</a>)</li>
 </ul>
-<h3>MatBlazor 1.9.0</h3>
+<h4 class="mat-h4">MatBlazor 1.9.0</h4>
 <ul>
 <li>Update to .NET Core 3.0</li>
 </ul>
-<h3>MatBlazor 1.8.0</h3>
+<h4 class="mat-h4">MatBlazor 1.8.0</h4>
 <ul>
 <li>Update to .NET Core 3.0 RC 1</li>
 </ul>
-<h3>MatBlazor 1.7.4</h3>
+<h4 class="mat-h4">MatBlazor 1.7.4</h4>
 <ul>
 <li>Support arrow keys and Enter in Autocomplete #237 (Thanks to <a href="https://github.com/dga711">dga711</a>)</li>
 <li>MatDialog: New CanBeClosed property #241 (Thanks to <a href="https://github.com/dga711">dga711</a>)</li>
 <li>Fix: Enhanced MatSelect throws exception(#231) #242 (Thanks to <a href="https://github.com/aviezzi">aviezzi</a>)</li>
 </ul>
-<h3>MatBlazor 1.7.2</h3>
+<h4 class="mat-h4">MatBlazor 1.7.2</h4>
 <ul>
 <li>PR: Add some padding to toasts #238 (Thanks to <a href="https://github.com/dga711">dga711</a>)</li>
 <li>PR: AutoComplete list cleaner look #239 (Thanks to <a href="https://github.com/dga711">dga711</a>)</li>
 </ul>
-<h3>MatBlazor 1.7.1</h3>
+<h4 class="mat-h4">MatBlazor 1.7.1</h4>
 <ul>
 <li>Change info in Nuget package</li>
 </ul>
-<h3>MatBlazor 1.7.0</h3>
+<h4 class="mat-h4">MatBlazor 1.7.0</h4>
 <ul>
 <li>Update to .NET Core 3.0 Preview 9</li>
 <li>PR: Return Toast instance on IMatToaster.Add method #228 (Thanks to <a href="https://github.com/Sebbstar">Sebbstar</a>)</li>
 <li>PR: Replaced all @@functions by @@code. #233 (Thanks to <a href="https://github.com/SeppPenner">SeppPenner</a>)</li>
 </ul>
-<h3>MatBlazor 1.6.4</h3>
+<h4 class="mat-h4">MatBlazor 1.6.4</h4>
 <ul>
 <li>Fix: MatAutocomplete StringValue clearing #216 (Thanks to <a href="https://github.com/lukblazewicz">lukblazewicz</a>)</li>
 <li>Fix: MatSelect option list in enhanced mode showing example list #221 (Thanks to <a href="https://github.com/aviezzi">aviezzi</a>)</li>
 </ul>
-<h3>MatBlazor 1.6.3</h3>
+<h4 class="mat-h4">MatBlazor 1.6.3</h4>
 <ul>
 <li>MatTable: Fix broken paginator when infinite items selected #202 (Thanks to <a href="https://github.com/dga711">dga711</a>)</li>
 <li>MatDialog.IsOpenChanged now also fires on open #200 (Thanks to <a href="https://github.com/dga711">dga711</a></li>
 </ul>
-<h3>MatBlazor 1.6.2</h3>
+<h4 class="mat-h4">MatBlazor 1.6.2</h4>
 <ul>
 <li>Fixed: MatTooltip: Position inside <code>&lt;table&gt;</code> is off #195</li>
 </ul>
-<h3>MatBlazor 1.6.1</h3>
+<h4 class="mat-h4">MatBlazor 1.6.1</h4>
 <ul>
 <li>Check ComponentContext.IsConnected for all Js-Invoke's
 <ul>
@@ -277,42 +277,42 @@
 </li>
 <li>PR: Incorporate validation styling and improve EditContext demo #190 (Thanks to <a href="https://github.com/ebekker">ebekker</a>)</li>
 </ul>
-<h3>MatBlazor 1.6.0</h3>
+<h4 class="mat-h4">MatBlazor 1.6.0</h4>
 <ul>
 <li>Update to .NET Core 3.0 Preview 8</li>
 </ul>
-<h3>MatBlazor 1.5.4</h3>
+<h4 class="mat-h4">MatBlazor 1.5.4</h4>
 <ul>
 <li>Fix of EditContext for MatDatePicker</li>
 </ul>
-<h3>MatBlazor 1.5.3</h3>
+<h4 class="mat-h4">MatBlazor 1.5.3</h4>
 <ul>
 <li>PR: Add flatpickr options to MatDatePicker #182 (Thanks to <a href="https://github.com/djinnet">djinnet</a>)</li>
 <li>PR: Initial support for EditContext-based validation #178 (Thanks to <a href="https://github.com/ebekker">ebekker</a>)</li>
 </ul>
-<h3>MatBlazor 1.5.2</h3>
+<h4 class="mat-h4">MatBlazor 1.5.2</h4>
 <ul>
 <li>PR: Adding example for nested sub menus and new &quot;toggle all&quot; feature #176 (Thanks to <a href="https://github.com/ebekker">ebekker</a>)</li>
 </ul>
-<h3>MatBlazor 1.5.1</h3>
+<h4 class="mat-h4">MatBlazor 1.5.1</h4>
 <ul>
 <li>PR: Adding support for nested NavSubMenus #174 (Thanks to <a href="https://github.com/ebekker">ebekker</a>)</li>
 </ul>
-<h3>MatBlazor 1.5.0</h3>
+<h4 class="mat-h4">MatBlazor 1.5.0</h4>
 <ul>
 <li>MatCard improvements</li>
 </ul>
-<h3>MatBlazor 1.4.1</h3>
+<h4 class="mat-h4">MatBlazor 1.4.1</h4>
 <ul>
 <li>MatTypography improvements</li>
 </ul>
-<h3>MatBlazor 1.4.0</h3>
+<h4 class="mat-h4">MatBlazor 1.4.0</h4>
 <ul>
 <li>New NavMenu - new component (Thanks to <a href="https://github.com/enkodellc">enkodellc</a>)</li>
 <li>PR: NumericUpDown to preview7. Fix tabindex #161 (Thanks to <a href="https://github.com/ctrl-alt-d">ctrl-alt-d</a>)</li>
 <li>PR: Outlined #162 (Thanks to <a href="https://github.com/ctrl-alt-d">ctrl-alt-d</a>)</li>
 </ul>
-<h3>MatBlazor 1.3.0</h3>
+<h4 class="mat-h4">MatBlazor 1.3.0</h4>
 <ul>
 <li>Update to .NET Core 3.0 Preview 7</li>
 <li>All components supports @@Attributes and Id parameter</li>
@@ -329,109 +329,109 @@
 <li>Now we have <a href="https://samprof.github.io/MatBlazor/">MatBlazor - Documentation and demo website - Client Side Blazor</a></li>
 <li>Fixed: Docs site looks to show bug for expansion panel #107</li>
 </ul>
-<h3>MatBlazor 1.2.0</h3>
+<h4 class="mat-h4">MatBlazor 1.2.0</h4>
 <ul>
 <li>.NET Core 3.0.100-preview6-012264</li>
 <li>MatToast (Thanks to <a href="https://github.com/enkodellc">enkodellc</a>)</li>
 <li>MatNumericUpDownField (Thanks to <a href="https://github.com/ctrl-alt-d">ctrl-alt-d</a>)</li>
 <li>PR: MatTable bug where LoadData would throw exception when using Filter #101 (Thanks to <a href="https://github.com/Garderoben">Garderoben</a>)</li>
 </ul>
-<h3>MatBlazor 1.1.1</h3>
+<h4 class="mat-h4">MatBlazor 1.1.1</h4>
 <ul>
 <li>Fixed Clicking on Icon in DatePicker doesn't show the calender selection window. #86</li>
 </ul>
-<h3>MatBlazor 1.1.0</h3>
+<h4 class="mat-h4">MatBlazor 1.1.0</h4>
 <ul>
 <li>MatHidden</li>
 </ul>
-<h3>MatBlazor 1.0.1</h3>
+<h4 class="mat-h4">MatBlazor 1.0.1</h4>
 <ul>
 <li>Material theme configuration #90</li>
 </ul>
-<h3>MatBlazor 1.0.0</h3>
+<h4 class="mat-h4">MatBlazor 1.0.0</h4>
 <ul>
 <li>MatAccordion, MatExpansionPanel</li>
 <li>MatTooltip</li>
 <li>ForwardRef concept</li>
 </ul>
-<h3>MatBlazor 0.9.14</h3>
+<h4 class="mat-h4">MatBlazor 0.9.14</h4>
 <ul>
 <li>MatFAB - Floating Action Button</li>
 </ul>
-<h3>MatBlazor 0.9.13</h3>
+<h4 class="mat-h4">MatBlazor 0.9.13</h4>
 <ul>
 <li>MatThemeProvider (Themes support)</li>
 <li>MatAppBarContainer, MatAppBarContent</li>
 <li>PR: MatNumericUpDownField #78 - early preview (ctrl-alt-d)</li>
 <li>MatMenu fix (added class and style support)</li>
 </ul>
-<h3>MatBlazor 0.9.12</h3>
+<h4 class="mat-h4">MatBlazor 0.9.12</h4>
 <ul>
 <li>MatDatePicker (alpha)</li>
 <li>MatTextField ReadOnly</li>
 <li>MatTextField InputClass and InputStyle</li>
 <li>MatButton Type, Name, Value #75</li>
 </ul>
-<h3>MatBlazor 0.9.11</h3>
+<h4 class="mat-h4">MatBlazor 0.9.11</h4>
 <ul>
 <li>MatTabGroup and MatTab components</li>
 <li>MatTabBar and MatTabLabel components</li>
 </ul>
-<h3>MatBlazor 0.9.10</h3>
+<h4 class="mat-h4">MatBlazor 0.9.10</h4>
 <ul>
 <li>Update to ASP.NET Core 3.0.0-preview5-19227-01</li>
 <li><a href="https://www.matblazor.com">https://www.matblazor.com</a> working as server-side Blazor on Linux server</li>
 <li>Fix MatAutoComplete</li>
 <li>Minor improvements and changes</li>
 </ul>
-<h3>MatBlazor 0.9.9</h3>
+<h4 class="mat-h4">MatBlazor 0.9.9</h4>
 <ul>
 <li>Demo and documentation <a href="https://www.matblazor.com">https://www.matblazor.com</a> working as server-side Blazor</li>
 <li><code>&lt;MatBlazorInstall /&gt;</code> for server-side Blazor is obsolete</li>
 <li>For server-side Blazor used <a href="https://github.com/SamProf/EmbeddedBlazorContent">EmbeddedBlazorContent</a> <a href="https://www.nuget.org/packages/EmbeddedBlazorContent/"><img src="https://img.shields.io/nuget/v/EmbeddedBlazorContent.svg" alt="NuGet" /></a></li>
 </ul>
-<h3>MatBlazor 0.9.8</h3>
+<h4 class="mat-h4">MatBlazor 0.9.8</h4>
 <ul>
 <li>New github path: <a href="https://github.com/SamProf/MatBlazor">https://github.com/SamProf/MatBlazor</a></li>
 <li>New gitter chat: <a href="https://gitter.im/MatBlazor/community">https://gitter.im/MatBlazor/community</a></li>
 </ul>
-<h3>MatBlazor 0.9.7</h3>
+<h4 class="mat-h4">MatBlazor 0.9.7</h4>
 <ul>
 <li>Fixed Drawer problem</li>
 </ul>
-<h3>MatBlazor 0.9.6</h3>
+<h4 class="mat-h4">MatBlazor 0.9.6</h4>
 <ul>
 <li>All components in one namespace MatBlazor (only one using directive)</li>
 <li>PR: Revert back to C# 7.3 #66 (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.9.5</h3>
+<h4 class="mat-h4">MatBlazor 0.9.5</h4>
 <ul>
 <li>Fixed problem with including *.razor files</li>
 <li>PR: #63 MatBlazor Logo / .svg / .ico #65 (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.9.4</h3>
+<h4 class="mat-h4">MatBlazor 0.9.4</h4>
 <ul>
 <li>Now we have Logo (many thanks to <a href="https://github.com/enkodellc">enkodellc</a>)</li>
 <li>PR: Prevent *.razor files from being packed #64 (IvanJosipovic)</li>
 <li>Fixed Examples generation</li>
 </ul>
-<h3>MatBlazor 0.9.3</h3>
+<h4 class="mat-h4">MatBlazor 0.9.3</h4>
 <ul>
 <li>Update to Blazor 3.0.0-preview4-19216-03</li>
 <li>PR: MatTable Table Filter, get data from API #61 (enkodellc, arivera12)</li>
 <li>PR: Fix Table Navigation Error #60 (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.9.2</h3>
+<h4 class="mat-h4">MatBlazor 0.9.2</h4>
 <ul>
 <li>PR: MatTable Version 1 #58 (enkodellc, arivera12)</li>
 </ul>
-<h3>MatBlazor 0.9.1</h3>
+<h4 class="mat-h4">MatBlazor 0.9.1</h4>
 <ul>
 <li>PR: Fixed #50 Autocomplete FullWidth + #52 (sandrohanea)</li>
 <li>PR: MatIconButton Add Functionality, Update Demo #53 (enkodellc)</li>
 <li>PR: Added documentation for autocomplete + Fixed #56 + changed documentation file path to a relative one(instead of absolut) #57 (sandrohanea)</li>
 </ul>
-<h3>MatBlazor 0.9.0</h3>
+<h4 class="mat-h4">MatBlazor 0.9.0</h4>
 <ul>
 <li>Creating partial documentation for all components (autogeneration)</li>
 <li>Improved many examples</li>
@@ -439,85 +439,85 @@
 <li>Change of versioning policy is similar to Blazor</li>
 <li>Fixed MatTextBox FullWidth Padding / Icon Fix #43 #51 (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.6.17</h3>
+<h4 class="mat-h4">MatBlazor 0.6.17</h4>
 <ul>
 <li>Fixed Select is showing native arrow? #48 (sandrohanea)</li>
 </ul>
-<h3>MatBlazor 0.6.16</h3>
+<h4 class="mat-h4">MatBlazor 0.6.16</h4>
 <ul>
 <li>New component MatAutocomplete (sandrohanea)</li>
 </ul>
-<h3>New domain name</h3>
+<h4 class="mat-h4">New domain name</h4>
 <ul>
 <li><a href="https://www.matblazor.com">www.matblazor.com</a></li>
 </ul>
-<h3>MatBlazor 0.6.15</h3>
+<h4 class="mat-h4">MatBlazor 0.6.15</h4>
 <ul>
 <li>New component MatSnackbar</li>
 </ul>
-<h3>MatBlazor 0.6.14</h3>
+<h4 class="mat-h4">MatBlazor 0.6.14</h4>
 <ul>
 <li>New component MatRipple</li>
 </ul>
-<h3>MatBlazor 0.6.13</h3>
+<h4 class="mat-h4">MatBlazor 0.6.13</h4>
 <ul>
 <li>New styles Layout Grid</li>
 </ul>
-<h3>MatBlazor 0.6.12</h3>
+<h4 class="mat-h4">MatBlazor 0.6.12</h4>
 <ul>
 <li>New component MatDialog</li>
 <li>MatCheckbox add inline label (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.6.11</h3>
+<h4 class="mat-h4">MatBlazor 0.6.11</h4>
 <ul>
 <li>New component MatProgressBar</li>
 </ul>
-<h3>MatBlazor 0.6.10</h3>
+<h4 class="mat-h4">MatBlazor 0.6.10</h4>
 <ul>
 <li>New styles Elevation</li>
 <li>License of used packages added to js boundle</li>
 </ul>
-<h3>MatBlazor 0.6.9</h3>
+<h4 class="mat-h4">MatBlazor 0.6.9</h4>
 <ul>
 <li>Changed all events to EventCallback</li>
 <li>Show Icons when MatTextField has FullWidth (enkodellc)</li>
 </ul>
-<h3>MatBlazor 0.6.8</h3>
+<h4 class="mat-h4">MatBlazor 0.6.8</h4>
 <ul>
 <li>Improved events for MatTextField (sandrohanea + SamProf)</li>
 </ul>
-<h3>MatBlazor 0.6.7</h3>
+<h4 class="mat-h4">MatBlazor 0.6.7</h4>
 <ul>
 <li>Added Typography styles</li>
 </ul>
-<h3>MatBlazor 0.6.6</h3>
+<h4 class="mat-h4">MatBlazor 0.6.6</h4>
 <ul>
 <li>Added Href parameter to MatListItem component</li>
 </ul>
-<h3>MatBlazor 0.6.5</h3>
+<h4 class="mat-h4">MatBlazor 0.6.5</h4>
 <ul>
 <li>MatTextField - fixed label</li>
 </ul>
-<h3>MatBlazor 0.6.4</h3>
+<h4 class="mat-h4">MatBlazor 0.6.4</h4>
 <ul>
 <li>MatMenu - first working implementation</li>
 </ul>
-<h3>MatBlazor 0.6.3</h3>
+<h4 class="mat-h4">MatBlazor 0.6.3</h4>
 <ul>
 <li>New MatDrawer</li>
 <li>Fix MatAppBar (fixed-adjust div)</li>
 </ul>
-<h3>MatBlazor 0.6.2</h3>
+<h4 class="mat-h4">MatBlazor 0.6.2</h4>
 <ul>
 <li>Added Style Parameter for all components</li>
 <li>Added BaseMatComponent Docs</li>
 <li>MatDrawer in progress</li>
 </ul>
-<h3>MatBlazor 0.6.1</h3>
+<h4 class="mat-h4">MatBlazor 0.6.1</h4>
 <ul>
 <li>Introduce Razor Components support (MatBlazorInstall component)</li>
 </ul>
-<h3>MatBlazor 0.6.0</h3>
+<h4 class="mat-h4">MatBlazor 0.6.0</h4>
 <ul>
 <li>Upgrade Blazor 0.9 complete</li>
 <li>Upgrade to new Material Components</li>
@@ -530,20 +530,20 @@
 <li>MatDrawer (prepared for development in next release)</li>
 <li>BlazorFiddle integration fixed</li>
 </ul>
-<h3>MatBlazor 0.5.0</h3>
+<h4 class="mat-h4">MatBlazor 0.5.0</h4>
 <ul>
 <li>Upgrade to Blazor 0.9.0 (Part 1)</li>
 </ul>
-<h3>MatBlazor 0.4.5 (Minor)</h3>
+<h4 class="mat-h4">MatBlazor 0.4.5 (Minor)</h4>
 <ul>
 <li>TrailingIcon in MatButton</li>
 </ul>
-<h3>MatBlazor 0.4.4</h3>
+<h4 class="mat-h4">MatBlazor 0.4.4</h4>
 <ul>
 <li>Added integration with BlazorFiddle.com</li>
 <li>MatIconButton - Href bacame Link</li>
 </ul>
-<h3>MatBlazor 0.4.3</h3>
+<h4 class="mat-h4">MatBlazor 0.4.3</h4>
 <ul>
 <li>Upgrade to Blazor 0.7.0</li>
 <li>MatDrawer in progress</li>

--- a/src/MatBlazor.Demo/Shared/Sponsors.razor
+++ b/src/MatBlazor.Demo/Shared/Sponsors.razor
@@ -1,6 +1,6 @@
 @* THIS IS AUTO GENERATED FILE!!! *@
 
-<h2>Sponsors &amp; Backers</h2>
+<h2 class="mat-h2">Sponsors &amp; Backers</h2>
 <p>MatBlazor does not run under the umbrella of any company or anything like that.
 It is an independent project created in spare time.
 The development is active and we are working hard to release great things for you.</p>
@@ -9,14 +9,14 @@ The development is active and we are working hard to release great things for yo
 <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=9XT68N2VKWTPE&amp;source=url">PayPal</a></li>
 <li><a href="https://www.patreon.com/SamProf">Patreon</a></li>
 </ul>
-<h3>Sponsors:</h3>
+<h4 class="mat-h4">Sponsors:</h4>
 <ul>
 <li>Phil Parkin</li>
 <li>Patreon: Jay Arrowz</li>
 <li>Patreon: Rene Zaal</li>
 <li>Patreon: Stas Levich</li>
 </ul>
-<h3>Backers:</h3>
+<h4 class="mat-h4">Backers:</h4>
 <ul>
 <li>Oyvind Habberstad</li>
 <li><a href="https://github.com/lindespang">Victor Lindespång</a></li>

--- a/src/MatBlazor.Demo/wwwroot/site.css
+++ b/src/MatBlazor.Demo/wwwroot/site.css
@@ -142,3 +142,9 @@
     white-space: nowrap;
     overflow: auto;
 }
+
+.body-wrapper {
+    max-width: 1280px;
+    padding: 24px;
+    margin: 0 auto;
+}

--- a/src/MatBlazor.DevUtils/Core/MatDocumenationGenerator.cs
+++ b/src/MatBlazor.DevUtils/Core/MatDocumenationGenerator.cs
@@ -101,7 +101,7 @@ namespace MatBlazor.DevUtils.Core
 
 //                sb.AppendLine($"<h5 class=\"mat-h5\">Documentation</h5>");
 
-                    sb.AppendLine($"<div><table class=\"article-table mat-elevation-z5\">");
+                    sb.AppendLine($"<div><table class=\"article-table mat-elevation-z5 mdc-theme--surface\">");
                     sb.AppendLine($"\t<tr>");
                     sb.AppendLine($"\t\t<th>Name</th>");
                     sb.AppendLine($"\t\t<th>Type</th>");

--- a/src/MatBlazor.DevUtils/MDInfoGenerator.cs
+++ b/src/MatBlazor.DevUtils/MDInfoGenerator.cs
@@ -30,7 +30,11 @@ namespace MatBlazor.DevUtils
 
             var result = CommonMark.CommonMarkConverter.Convert(text);
 
-            result = result.Replace("@", "@@");
+            result = result.Replace("@", "@@").Replace(@"<h5>", @"<h5 class=""mat-h5"">")
+                                              .Replace(@"<h4>", @"<h4 class=""mat-h4"">")
+                                              .Replace(@"<h3>", @"<h3 class=""mat-h3"">")
+                                              .Replace(@"<h2>", @"<h2 class=""mat-h2"">")
+                                              .Replace(@"<h1>", @"<h1 class=""mat-h1"">"); ;
 
             Console.WriteLine(result);
 


### PR DESCRIPTION
Hi! I've done a redesign on MatBlazor.com.

# Summary of changes:
- New color scheme, all theming is done by matblazor theme together with mdc classes

    -  Primary: Blazor purple
    - Secondary: Unchanged
    - Background: Material paper grey
    - Surface: White

- Single column body with fixed width
- Removed components from startpage
- Normalized inconsistent headers in README.md
- Added material header classes to html generated from README.md

# Screenshots
![pr1](https://user-images.githubusercontent.com/36196344/84648855-e3d05500-af05-11ea-82e5-b488e8b95d98.PNG)

![pr2](https://user-images.githubusercontent.com/36196344/84648837-da46ed00-af05-11ea-9d0c-f14c731bbd5e.PNG)

![pr3](https://user-images.githubusercontent.com/36196344/84648873-e7fc7280-af05-11ea-8cee-e32e95ae4329.PNG)