### PR TITLE
Fix part of #659

### DIFF
--- a/src/MatBlazor/Components/MatTextField/BaseMatInputTextComponent.cs
+++ b/src/MatBlazor/Components/MatTextField/BaseMatInputTextComponent.cs
@@ -146,11 +146,17 @@ namespace MatBlazor
                     () => this.FullWidth && this.Icon != null && this.IconTrailing)
                 .If("mdc-text-field--textarea", () => this.TextArea);
 
+            bool TextOrPlaceHolderVisible()
+            {
+                return !string.IsNullOrEmpty(CurrentValueAsString)
+                    || (!string.IsNullOrWhiteSpace(PlaceHolder) && FullWidth);
+            }
+
             LabelClassMapper
                 .Add("mdc-floating-label")
                 .If("mat-floating-label--float-above-outlined",
-                    () => Outlined && !string.IsNullOrEmpty(CurrentValueAsString))
-                .If("mdc-floating-label--float-above", () => !string.IsNullOrEmpty(CurrentValueAsString));
+                    () => Outlined && TextOrPlaceHolderVisible())
+                .If("mdc-floating-label--float-above", () => TextOrPlaceHolderVisible());
 
             InputClassMapper
                 .Get(() => this.InputClass)


### PR DESCRIPTION
This addresses #659.

There are still issues here, but I think it's probably in JS: when focus is lost on the textfield, the `mat-floating-label--float-above` is removed, irrespective of existance of text or placeholder. Needs some more investigation.

What's fixed here is the situation where overlap occurs when the value is not just whitespace or when the placeholder is not just whitespace and should be visible.