### PR TITLE
Added component MatButtonLink

### DIFF
--- a/src/MatBlazor.Demo/Demo/DemoMatButtonLink.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatButtonLink.razor
@@ -1,0 +1,194 @@
+@using Microsoft.AspNetCore.Components
+@inject IJSRuntime JsRuntime
+
+<DocMatButtonLink></DocMatButtonLink>
+
+<h5 class="mat-h5">Example</h5>
+<DemoContainer>
+    <Content>
+        <h4 class="mat-subtitle1">Simple use</h4>
+        <MatButtonLink Icon="favorite" Href="/ButtonLink">Link to this page</MatButtonLink>
+
+        <h4 class="mat-subtitle1">Link with OnClick event handler</h4>
+        <MatButtonLink Icon="favorite" Href="/ButtonLink" OnClick="@RunOnClick">Link with click event</MatButtonLink>
+
+        <h5 class="mat-subtitle1">With Font-Awesome Icons and Link</h5>
+        <MatButtonLink Href="https://github.com/BlazorComponents/MatBlazor">
+            <i class="fa fa-github" aria-hidden="true"></i> &nbsp; Github
+        </MatButtonLink>
+        
+        <h5 class="mat-subtitle1">Link to internal page</h5>
+        <MatButtonLink Href="/Checkbox">Go to Checkbox</MatButtonLink>
+
+        <h5 class="mat-subtitle1">Internal Link with ForceLoad</h5>
+        <MatButtonLink Href="/Checkbox" ForceLoad="true">ForceLoad - Go to Checkbox</MatButtonLink>
+
+        <h5 class="mat-subtitle1">With Font-Awesome Icons and Link in a new Window  - Target Defined</h5>
+        <MatButtonLink Href="https://github.com/BlazorComponents/MatBlazor" Target="_blank">
+            <i class="fa fa-github" aria-hidden="true"></i> &nbsp; Github
+        </MatButtonLink>
+
+        <h5 class="mat-subtitle1">Internal Link in a new Window - Target Defined</h5>
+        <MatButtonLink Href="/TextField" Target="_blank">
+            <i class="fa fa-paragraph" aria-hidden="true"></i> &nbsp; TextField
+        </MatButtonLink>
+
+        @code
+        {
+
+            public void RunOnClick(MouseEventArgs e)
+            {
+                JsRuntime.InvokeAsync<object>("window.alert", "Test");
+            }
+
+        }
+
+    </Content>
+    <SourceContent>
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <h4 class=""mat-subtitle1"">Simple use</h4>
+        <MatButtonLink Icon=""favorite"" Href=""/ButtonLink"">Link to this page</MatButtonLink>
+
+        <h4 class=""mat-subtitle1"">Link with OnClick event handler</h4>
+        <MatButtonLink Icon=""favorite"" Href=""/ButtonLink"" OnClick=""@RunOnClick"">Link with click event</MatButtonLink>
+
+        <h5 class=""mat-subtitle1"">With Font-Awesome Icons and Link</h5>
+        <MatButtonLink Href=""https://github.com/BlazorComponents/MatBlazor"">
+            <i class=""fa fa-github"" aria-hidden=""true""></i> &nbsp; Github
+        </MatButtonLink>
+        
+        <h5 class=""mat-subtitle1"">Link to internal page</h5>
+        <MatButtonLink Href=""/Checkbox"">Go to Checkbox</MatButtonLink>
+
+        <h5 class=""mat-subtitle1"">Internal Link with ForceLoad</h5>
+        <MatButtonLink Href=""/Checkbox"" ForceLoad=""true"">ForceLoad - Go to Checkbox</MatButtonLink>
+
+        <h5 class=""mat-subtitle1"">With Font-Awesome Icons and Link in a new Window  - Target Defined</h5>
+        <MatButtonLink Href=""https://github.com/BlazorComponents/MatBlazor"" Target=""_blank"">
+            <i class=""fa fa-github"" aria-hidden=""true""></i> &nbsp; Github
+        </MatButtonLink>
+
+        <h5 class=""mat-subtitle1"">Internal Link in a new Window - Target Defined</h5>
+        <MatButtonLink Href=""/TextField"" Target=""_blank"">
+            <i class=""fa fa-paragraph"" aria-hidden=""true""></i> &nbsp; TextField
+        </MatButtonLink>
+
+        @code
+        {
+
+            public void RunOnClick(MouseEventArgs e)
+            {
+                JsRuntime.InvokeAsync<object>(""window.alert"", ""Test"");
+            }
+
+        }
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>
+
+<h5 class="mat-h5">Link types</h5>
+<DemoContainer>
+    <Content>
+        <MatButtonLink Href="/ButtonLink" OnClick="@Click">Text @LinkState</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Raised="true">Raised</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Unelevated="true">Unelevated</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Outlined="true">Outlined</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Dense="true">Dense</MatButtonLink>
+
+        @code
+        {
+            string LinkState = "";
+
+            void Click(MouseEventArgs e)
+            {
+                LinkState = "Clicked";
+            }
+
+        }
+
+    </Content>
+    <SourceContent>
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <MatButtonLink Href=""/ButtonLink"" OnClick=""@Click"">Text @LinkState</MatButton>
+        <MatButtonLink Href=""/ButtonLink"" Raised=""true"">Raised</MatButton>
+        <MatButtonLink Href=""/ButtonLink"" Unelevated=""true"">Unelevated</MatButton>
+        <MatButtonLink Href=""/ButtonLink"" Outlined=""true"">Outlined</MatButton>
+        <MatButtonLink Href=""/ButtonLink"" Dense=""true"">Dense</MatButton>
+
+        @code
+        {
+            string LinkState = """";
+
+            void Click(MouseEventArgs e)
+            {
+                LinkState = ""Clicked"";
+            }
+
+        }
+
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>
+
+<h5 class="mat-h5">Disabled</h5>
+<DemoContainer>
+    <Content>
+        <MatButtonLink Href="/ButtonLink" Disabled="true">Text</MatButtonLink>
+        <MatButtonLink>Link without Href</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Raised="true" Disabled="true">Raised</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Unelevated="true" Disabled="true">Unelevated</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Outlined="true" Disabled="true">Outlined</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Dense="true" Disabled="true">Dense</MatButtonLink>
+    </Content>
+    <SourceContent>
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <MatButtonLink Href=""/ButtonLink"" Disabled=""true"">Text</MatButtonLink>
+        <MatButtonLink>Link without Href</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Raised=""true"" Disabled=""true"">Raised</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Unelevated=""true"" Disabled=""true"">Unelevated</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Outlined=""true"" Disabled=""true"">Outlined</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Dense=""true"" Disabled=""true"">Dense</MatButtonLink>
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>
+
+
+<h5 class="mat-h5">Icons</h5>
+<DemoContainer>
+    <Content>
+        <MatButtonLink Href="/ButtonLink" Icon="favorite">Text</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Raised="true" Icon="favorite">Raised</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Unelevated="true" Icon="favorite">Unelevated</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Outlined="true" Icon="favorite">Outlined</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Dense="true" Icon="favorite">Dense</MatButtonLink>
+    </Content>
+    <SourceContent>
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <MatButtonLink Href=""/ButtonLink"" Icon=""favorite"">Text</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Raised=""true"" Icon=""favorite"">Raised</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Unelevated=""true"" Icon=""favorite"">Unelevated</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Outlined=""true"" Icon=""favorite"">Outlined</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Dense=""true"" Icon=""favorite"">Dense</MatButtonLink>
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>
+
+<h5 class="mat-h5">Trailing Icons</h5>
+<DemoContainer>
+    <Content>
+        <MatButtonLink Href="/ButtonLink" TrailingIcon="favorite">Text</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Raised="true" TrailingIcon="favorite">Raised</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Unelevated="true" TrailingIcon="favorite">Unelevated</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Outlined="true" TrailingIcon="favorite">Outlined</MatButtonLink>
+        <MatButtonLink Href="/ButtonLink" Dense="true" TrailingIcon="favorite">Dense</MatButtonLink>
+    </Content>
+    <SourceContent>
+    	<BlazorFiddle Template="MatBlazor" Code=@(@"
+        <MatButtonLink Href=""/ButtonLink"" TrailingIcon=""favorite"">Text</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Raised=""true"" TrailingIcon=""favorite"">Raised</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Unelevated=""true"" TrailingIcon=""favorite"">Unelevated</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Outlined=""true"" TrailingIcon=""favorite"">Outlined</MatButtonLink>
+        <MatButtonLink Href=""/ButtonLink"" Dense=""true"" TrailingIcon=""favorite"">Dense</MatButtonLink>
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>

--- a/src/MatBlazor.Demo/Pages/DemoMatButtonLinkPage.razor
+++ b/src/MatBlazor.Demo/Pages/DemoMatButtonLinkPage.razor
@@ -1,0 +1,4 @@
+@page "/ButtonLink"
+
+
+<DemoMatButtonLink></DemoMatButtonLink>

--- a/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
+++ b/src/MatBlazor.Demo/Shared/DemoDrawerContent.razor
@@ -155,6 +155,12 @@
             },
             new NavItem()
             {
+                Name = "ButtonLink",
+                Url = "ButtonLink",
+                Group = groups.Navigation
+            },
+            new NavItem()
+            {
                 Name = "Dialog",
                 Url = "Dialog",
                 Group = groups.PopupsAndModals

--- a/src/MatBlazor.Web/src/matButton/matButton.scss
+++ b/src/MatBlazor.Web/src/matButton/matButton.scss
@@ -4,17 +4,25 @@
   margin: 0 -4px 0 4px !important;
 }
 
-.mat-link {
+.mat-button-link {
     text-align: center;
 }
 
-.mat-link:hover {
+.mat-button-link:hover {
     text-decoration: none;
 }
 
-.mat-link:not([href]) {
+.mat-button-link:not([href]) {
     color: rgba(0,0,0,.38) !important;
     cursor: default;
     pointer-events: none;
     background-color: transparent;
+}
+
+.mat-button-link.mdc-button--raised:not([href]) {
+    box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.2), 0px 0px 0px 0px rgba(0, 0, 0, 0.14), 0px 0px 0px 0px rgba(0,0,0,.12);
+}
+
+.mat-button-link.mdc-button--raised:not([href]), .mat-button-link.mdc-button--unelevated:not([href]) {
+    background-color: rgba(0,0,0,.12);
 }

--- a/src/MatBlazor.Web/src/matButton/matButton.scss
+++ b/src/MatBlazor.Web/src/matButton/matButton.scss
@@ -3,3 +3,18 @@
 .mat-button__icon--trailing {
   margin: 0 -4px 0 4px !important;
 }
+
+.mat-link {
+    text-align: center;
+}
+
+.mat-link:hover {
+    text-decoration: none;
+}
+
+.mat-link:not([href]) {
+    color: rgba(0,0,0,.38) !important;
+    cursor: default;
+    pointer-events: none;
+    background-color: transparent;
+}

--- a/src/MatBlazor/Components/MatLink/BaseMatLink.cs
+++ b/src/MatBlazor/Components/MatLink/BaseMatLink.cs
@@ -5,19 +5,22 @@ using System.Windows.Input;
 
 namespace MatBlazor
 {
-    public class BaseMatLink: BaseMatDomComponent
+    public class BaseMatButtonLink: BaseMatDomComponent
     {
+        [Inject]
+        public Microsoft.AspNetCore.Components.NavigationManager UriHelper { get; set; }
+
         protected async override Task OnFirstAfterRenderAsync()
         {
             await base.OnFirstAfterRenderAsync();
             await JsInvokeAsync<object>("matBlazor.matButton.init", Ref);
         }
 
-        public BaseMatLink()
+        public BaseMatButtonLink()
         {
             ClassMapper
                 .Add("mdc-button")
-                .Add("mat-link")
+                .Add("mat-button-link")
                 .If("mdc-button--raised", () => this.Raised)
                 .If("mdc-button--unelevated", () => this.Unelevated)
                 .If("mdc-button--outlined", () => this.Outlined)
@@ -50,6 +53,13 @@ namespace MatBlazor
         /// </summary>
         [Parameter]
         public string Href { get; set; }
+
+        /// <summary>
+        /// Force browser to redirect outside component router-space.
+        /// </summary>
+        /// 
+        [Parameter]
+        public bool ForceLoad { get; set; }
 
         /// <summary>
         /// Target of Link when clicked.
@@ -108,10 +118,20 @@ namespace MatBlazor
 
         protected async void OnClickHandler(MouseEventArgs ev)
         {
+            if (Disabled)
+            {
+                return;
+            }
+
             await OnClick.InvokeAsync(ev);
             if (Command?.CanExecute(CommandParameter) ?? false)
             {
                 Command.Execute(CommandParameter);
+            }
+
+            if (Href != null && string.IsNullOrEmpty(Target))
+            {
+                UriHelper.NavigateTo(Href, ForceLoad);
             }
         }
     }

--- a/src/MatBlazor/Components/MatLink/BaseMatLink.cs
+++ b/src/MatBlazor/Components/MatLink/BaseMatLink.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace MatBlazor
+{
+    public class BaseMatLink: BaseMatDomComponent
+    {
+        protected async override Task OnFirstAfterRenderAsync()
+        {
+            await base.OnFirstAfterRenderAsync();
+            await JsInvokeAsync<object>("matBlazor.matButton.init", Ref);
+        }
+
+        public BaseMatLink()
+        {
+            ClassMapper
+                .Add("mdc-button")
+                .Add("mat-link")
+                .If("mdc-button--raised", () => this.Raised)
+                .If("mdc-button--unelevated", () => this.Unelevated)
+                .If("mdc-button--outlined", () => this.Outlined)
+                .If("mdc-button--dense", () => this.Dense);
+        }
+
+        /// <summary>
+        /// Event occurs when the user clicks on an element.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+        /// <summary>
+        /// Stop propagation of the OnClick event
+        /// </summary>
+        [Parameter]
+        public bool OnClickStopPropagation { get; set; }
+
+        [Parameter]
+        public ICommand Command { get; set; }
+
+        /// <summary>
+        /// Command parameter.
+        /// </summary>
+        [Parameter]
+        public object CommandParameter { get; set; }
+
+        /// <summary>
+        /// Link to a url when clicked.
+        /// </summary>
+        [Parameter]
+        public string Href { get; set; }
+
+        /// <summary>
+        /// Target of Link when clicked.
+        /// </summary>
+        [Parameter]
+        public string Target { get; set; } = null;
+
+        /// <summary>
+        /// Link has raised style.
+        /// </summary>
+        [Parameter]
+        public bool Raised { get; set; }
+
+        /// <summary>
+        /// Link has unelevated style.
+        /// </summary>
+        [Parameter]
+        public bool Unelevated { get; set; }
+
+        /// <summary>
+        /// Link has outlined style.
+        /// </summary>
+        [Parameter]
+        public bool Outlined { get; set; }
+
+        /// <summary>
+        /// Link has dense style.
+        /// </summary>
+
+        [Parameter]
+        public bool Dense { get; set; }
+
+        /// <summary>
+        /// Link is disabled.
+        /// </summary>
+        [Parameter]
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// Specifies the link's icon.
+        /// </summary>
+        [Parameter]
+        public string Icon { get; set; }
+
+        /// <summary>
+        /// Specifies if icon has trailing position.
+        /// </summary>
+        [Parameter]
+        public string TrailingIcon { get; set; }
+
+        /// <summary>
+        /// Inline label of Button.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        protected async void OnClickHandler(MouseEventArgs ev)
+        {
+            await OnClick.InvokeAsync(ev);
+            if (Command?.CanExecute(CommandParameter) ?? false)
+            {
+                Command.Execute(CommandParameter);
+            }
+        }
+    }
+}

--- a/src/MatBlazor/Components/MatLink/MatLink.razor
+++ b/src/MatBlazor/Components/MatLink/MatLink.razor
@@ -1,5 +1,5 @@
 @namespace MatBlazor
-@inherits BaseMatLink
+@inherits BaseMatButtonLink
 
 <a href=@(Disabled ? null : Href) target="@Target" class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" @onclick="OnClickHandler" @onclick:stopPropagation=@OnClickStopPropagation aria-label="@Icon" @ref="Ref" @attributes="Attributes" id="@Id">
     <div class="mdc-button__ripple"></div>

--- a/src/MatBlazor/Components/MatLink/MatLink.razor
+++ b/src/MatBlazor/Components/MatLink/MatLink.razor
@@ -1,0 +1,15 @@
+@namespace MatBlazor
+@inherits BaseMatLink
+
+<a href=@(Disabled ? null : Href) target="@Target" class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" @onclick="OnClickHandler" @onclick:stopPropagation=@OnClickStopPropagation aria-label="@Icon" @ref="Ref" @attributes="Attributes" id="@Id">
+    <div class="mdc-button__ripple"></div>
+    @if (Icon != null)
+    {
+        <span class="material-icons mdc-button__icon">@Icon</span>
+    }
+    @ChildContent
+    @if (TrailingIcon != null)
+    {
+        <span class="material-icons mdc-button__icon mat-button__icon--trailing">@TrailingIcon</span>
+    }
+</a>


### PR DESCRIPTION
**`MatButtonLink`** is a link component styled exactly like a `MatButton`.

The `MatButton` component already has a `Link` parameter but it is in fact a _button_ and doesn't have the features of a _link_ like being able to open in a new tab, copying the link address e.t.c....
The styles are based on `mdc-button` styles, but extra styles are added for a class "mat-button-link"
It doesn't have `Name`, `Value`, `Label` and `Type` params which are present in `MatButton`, and `Link` param was renamed to `Href`. Every other parameter from `MatButton` is present.