### PR TITLE
Fixes MatChip TrailingIconClick

### DIFF
--- a/src/MatBlazor/Components/MatChip/MatChip.razor
+++ b/src/MatBlazor/Components/MatChip/MatChip.razor
@@ -19,6 +19,6 @@
     <div class="mdc-chip__text">@Label</div>
     @if (TrailingIcon != null)
     {
-       <i class="material-icons mdc-chip__icon mdc-chip__icon--trailing">@TrailingIcon</i>
+       <i class="material-icons mdc-chip__icon mdc-chip__icon--trailing mdc-chip-trailing-action">@TrailingIcon</i>
     }
 </div>


### PR DESCRIPTION
It looks like the update to MDC 7.0.0 ended up braking the MatChip component's TrailingIconClick. According to [this MDC issue](https://github.com/material-components/material-components-web/issues/6136) it's because the `mdc-chip-trailing-action` CSS class should be on the remove trailing icon. This PR adds this class.

I've confirmed locally that the TrailingIconClick event fires when this change is made. This should resolve [issue #724](https://github.com/SamProf/MatBlazor/issues/724).