### PR TITLE
feat: apply surface color as background color for text field component

### DIFF
--- a/src/MatBlazor.Demo/Demo/DemoThemes.razor
+++ b/src/MatBlazor.Demo/Demo/DemoThemes.razor
@@ -23,6 +23,11 @@
                                                                                              Theme.Secondary = _;
                                                                                              this.Theme.ThemeHasChanged();
                                                                                          })" OnFocus="@(_ => colorType = ColorType.Secondary)" class="@(colorType == ColorType.Secondary ? "mat-elevation-z10" : null)"></MatStringField>
+                <MatStringField Value="@Theme.Surface"
+                                Label="Surface"
+                                ValueChanged="@(_ => { Theme.Surface = _; this.Theme.ThemeHasChanged(); })"
+                                OnFocus="@(_ => colorType = ColorType.Surface)" class="@(colorType == ColorType.Surface ? "mat-elevation-z10" : null)">
+                </MatStringField>
             </div>
 
             <ThemeColorSelector @bind-Value="@ColorValue"></ThemeColorSelector>
@@ -216,6 +221,8 @@
                     return Theme.Primary;
                 case ColorType.Secondary:
                     return Theme.Secondary;
+                case ColorType.Surface:
+                    return Theme.Surface;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -231,6 +238,9 @@
                 case ColorType.Secondary:
                     Theme.Secondary = value;
                     break;
+                case ColorType.Surface:
+                    Theme.Surface = value;
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -242,7 +252,8 @@
     enum ColorType
     {
         Primary,
-        Secondary
+        Secondary,
+        Surface
     }
 
 }

--- a/src/MatBlazor.Web/src/matTextField/matTextField.scss
+++ b/src/MatBlazor.Web/src/matTextField/matTextField.scss
@@ -116,6 +116,18 @@ label.mdc-text-field--fullwidth:not(.mdc-text-field--textarea) > span.mdc-floati
   color: var(--mdc-theme-primary, #6200ee);
 }
 
+.mdc-text-field {
+  background-color: var(--mdc-theme-surface, #fff);
+}
+
+.mdc-text-field--filled {
+  background-color: var(--mdc-theme-surface, #fff);
+}
+
+.mdc-text-field--filled:not(.mdc-text-field--disabled) {
+  background-color: var(--mdc-theme-surface, #fff);
+}
+
 /* More specific selector for translating the label to top */
 .mdc-text-field.mdc-text-field--fullwidth .mdc-floating-label.mdc-floating-label--float-above {
   transform: translateY(-106%) scale(0.75);


### PR DESCRIPTION
## Problem
I was using matblazor and my custom theme with dark color. I set background and surface as black but MatTextField still had white bg-color.
So, setting bg-color from -mdc-theme-surface is expected behavior for me. Only some elements (like table) use color from -mdc-theme-surface.
And this problem also connect with #82 

## Propose
1. Add surface color picker to DemoThemes
2. Add `background-color: var(--mdc-theme-surface, #fff)`  to MatTextField

## Also
I had some problems with this fix: it wasn't work after adding bg-color to `.mdc-text-field` because `mdc-text-field--filled:not(.mdc-text-field--disabled)` override this value. I don't know matblazor good enough and have no idea how to change generated value for `.mdc-text-field--filled:not(.mdc-text-field--disabled)` (there is no declaration for this class in MatBlazor.Web, probably it's generate on npm build)

## Result
![image](https://user-images.githubusercontent.com/22368203/102693458-c7520400-422b-11eb-8647-6eab535e2f8b.png)

## Known issues
My pr fix only MatTextField. We can see on screenshot that picker still has default bg-color. I will try to rework other control if this pr will be approved.