### PR TITLE
Specify a group name for MatRadioButtons on the MatRadioGroup and Double Navigation Fix

### DIFF
--- a/src/MatBlazor.Demo/Demo/DemoMatRadioButton.razor
+++ b/src/MatBlazor.Demo/Demo/DemoMatRadioButton.razor
@@ -101,6 +101,47 @@
     </SourceContent>
 </DemoContainer>
 
+<h5 class="mat-h5">Custom group name</h5>
+<DemoContainer>
+    <Content>
+        <h5 Class="mat-subtitle1">You can specify a group name for multiple MatRadioGroups.</h5>
+
+        <MatRadioGroup GroupName="gender" @bind-Value="@GenVal" TValue="string">
+            <MatRadioButton Value="@string.Empty" TValue="string">Default</MatRadioButton>
+            <MatRadioButton Value="@("f")" Label="Female" TValue="string"></MatRadioButton>
+            <MatRadioButton Value="@("m")" TValue="string">Male</MatRadioButton>
+        </MatRadioGroup>
+
+        <h5 Class="mat-subtitle1">This is useful when the MatRadioButtons can't all be children of the same MatRadioGroup. The below radio button is grouped with the ones above.</h5>
+
+        <MatRadioGroup GroupName="gender" @bind-Value="@GenVal" TValue="string">
+            <MatRadioButton Value="@("n")" TValue="string">Non-binary</MatRadioButton>
+        </MatRadioGroup>
+
+        @code
+        { protected string GenVal; }
+
+    </Content>
+    <SourceContent>
+        <BlazorFiddle Template="MatBlazor" Code=@(@"
+        <MatRadioGroup GroupName=""gender"" @bind-Value=""@GenVal"" TValue=""string"">
+            <MatRadioButton Value=""@string.Empty"" TValue=""string"">Default</MatRadioButton>
+            <MatRadioButton Value=""@(""f"")"" Label=""Female"" TValue=""string""></MatRadioButton>
+            <MatRadioButton Value=""@(""m"")"" TValue=""string"">Male</MatRadioButton>
+        </MatRadioGroup>
+
+        <MatRadioGroup GroupName=""gender"" @bind-Value=""@GenVal"" TValue=""string"">
+            <MatRadioButton Value=""@(""n"")"" TValue=""string"">Non-binary</MatRadioButton>
+        </MatRadioGroup>
+
+        @code
+        {
+            protected string GenVal;
+        }
+
+    ")></BlazorFiddle>
+    </SourceContent>
+</DemoContainer>
 
 <h5 class="mat-h5">Custom Class</h5>
 <DemoContainer>

--- a/src/MatBlazor.Demo/Doc/DocMatRadioGroup.razor
+++ b/src/MatBlazor.Demo/Doc/DocMatRadioGroup.razor
@@ -35,6 +35,11 @@
 		<td>Specifies one or more classnames for an DOM element.</td>
 	</tr>
 	<tr>
+		<td>GroupName</td>
+		<td>String</td>
+		<td>Specifies a group name for the radio buttons.</td>
+	</tr>
+	<tr>
 		<td>Id</td>
 		<td>String</td>
 		<td></td>

--- a/src/MatBlazor/Components/MatButtonLink/BaseMatLink.cs
+++ b/src/MatBlazor/Components/MatButtonLink/BaseMatLink.cs
@@ -129,9 +129,9 @@ namespace MatBlazor
                 Command.Execute(CommandParameter);
             }
 
-            if (Href != null && string.IsNullOrEmpty(Target))
+            if (Href != null && string.IsNullOrEmpty(Target) && ForceLoad)
             {
-                UriHelper.NavigateTo(Href, ForceLoad);
+                UriHelper.NavigateTo(Href, true);
             }
         }
     }

--- a/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
+++ b/src/MatBlazor/Components/MatNavMenu/BaseMatNavItem.cs
@@ -110,9 +110,9 @@ namespace MatBlazor
                 {
                     // Do nothing here as it is a target for an anchor tag
                 }
-                else
+                else if(ForceLoad)
                 {
-                    UriHelper.NavigateTo(Href, ForceLoad);
+                    UriHelper.NavigateTo(Href, true);
                 }
 
             }

--- a/src/MatBlazor/Components/MatRadioButton/BaseMatRadioGroupInternal.cs
+++ b/src/MatBlazor/Components/MatRadioButton/BaseMatRadioGroupInternal.cs
@@ -10,6 +10,9 @@ namespace MatBlazor
     public class BaseMatRadioGroupInternal<TValue> : BaseMatInputComponent<TValue>
     {
         [Parameter]
+        public string GroupName { get; set; }
+        
+        [Parameter]
         public RenderFragment<TValue> ItemTemplate { get; set; }
 
         [Parameter]

--- a/src/MatBlazor/Components/MatRadioButton/MatRadioButtonInternal.razor
+++ b/src/MatBlazor/Components/MatRadioButton/MatRadioButtonInternal.razor
@@ -5,7 +5,7 @@
 
 <div class="mdc-form-field" @ref="FormFieldRef">
     <div class="@ClassMapper.AsString()" style="@StyleMapper.AsString()" @ref="Ref">
-        <input class="mdc-radio__native-control" type="radio" name="@Group.Id" checked="@Checked" value="@ValueAsString"
+        <input class="mdc-radio__native-control" type="radio" name="@(Group.GroupName ?? Group.Id)" checked="@Checked" value="@ValueAsString"
                @onchange="((e) => OnChangeHandler(e))" id="@Id" disabled=@Disabled @attributes="Attributes" />
         <div class="mdc-radio__background">
             <div class="mdc-radio__outer-circle"></div>


### PR DESCRIPTION
This pull request introduces a feature and a fix, but I didn't know how to seperate them into different pull requests.

1. Added the ability to specify a custom group name to be used to group radio buttons. If not specified, the Group.Id will be used instead. This pull request addresses most of #789.

![image](https://user-images.githubusercontent.com/45200292/103298272-41d40e00-49fa-11eb-8e09-d75facb98bf3.png)

2. Fixed double navigation for MatNavItem and MatButtonLink. This pull request addresses #802. The cause of the double Navigation was UriHelper.NavigateTo(). Since it is already a link, this isn't needed unless ForceLoad is true.