### PR TITLE
Some minor MatTable fixes.

### DIFF
--- a/src/MatBlazor/Components/MatTable/MatTable.razor
+++ b/src/MatBlazor/Components/MatTable/MatTable.razor
@@ -341,13 +341,15 @@
 
                 ItemList = PageSize <= 0 ? filteredCollection : filteredCollection.Skip(RecordsFrom).Take(PageSize);
             }
-            else
+            else if (Items != null)
             {
                 ItemList = PageSize <= 0 ? Items : Items.Skip(RecordsFrom).Take(PageSize);
                 RecordsTo = (RecordsFrom + PageSize < Items.Count()) ? RecordsFrom + PageSize : Items.Count();
                 TotalPages = Math.Max(1, (int)Math.Ceiling(Items.Count() / (decimal)PageSize));
                 EndPage = TotalPages;
             }
+            else { } // Do nothing
+
             SetPageSize(PageDirection.Next);
             StateHasChanged();
         }

--- a/src/MatBlazor/Components/MatTable/MatTable.razor
+++ b/src/MatBlazor/Components/MatTable/MatTable.razor
@@ -141,7 +141,7 @@
 
         var lastComma = tempPlaceholder.LastIndexOf(",");
 
-        if (lastComma != -1)
+        if (lastComma != -1 && SearchTermFieldPlaceHolder == null)
         {
             SearchTermFieldPlaceHolder = tempPlaceholder.Remove(lastComma, 1).Insert(lastComma, " and");
         }


### PR DESCRIPTION
- No longer overwrite custom MatTable search field placeholder
- No longer throw NullReferenceException on loading MatTable data when Items = null (unnecessary debugger stop - when set to break on error)